### PR TITLE
fix(cli_runtime): 订阅接入在中文 Windows 上返回空白（强制 UTF-8 解码子进程输出）

### DIFF
--- a/backend/cli_runtime.py
+++ b/backend/cli_runtime.py
@@ -121,6 +121,8 @@ def run_cli(kind: str, system_prompt: str, user_prompt: str) -> str:
                 input=stdin_payload,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 cwd=tmpdir,
                 env=env,
                 timeout=_CLI_TIMEOUT_S,
@@ -168,6 +170,7 @@ def run_cli_stream(kind: str, system_prompt: str, user_prompt: str):
         proc = subprocess.Popen(
             [bin_path, *args], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL, cwd=tmpdir, env=env, text=True, bufsize=1,
+            encoding="utf-8", errors="replace",
         )
         if stdin_payload is not None:
             try:


### PR DESCRIPTION

## 问题

在**中文 Windows**（系统默认编码 GBK / cp936）上，「订阅接入」调用本机 CLI（Claude Code / Qwen / Gemini / DeepSeek / Codex）作答时，前端「拆板块 / 每日复盘 / 问 AI」等一切走订阅接入的功能**都返回空白**。

## 根因

`backend/cli_runtime.py` 里 `run_cli`（`subprocess.run`）和 `run_cli_stream`（`subprocess.Popen`）都用了 `text=True` 但未指定 `encoding`。`text=True` 会用**本地默认编码**解码子进程 stdout——在中文 Windows 上即 GBK。而各 CLI 输出的是 **UTF-8**（内含中文），于是解码抛 `UnicodeDecodeError`：

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa1 in position 16: illegal multibyte sequence
```

- 非流式 `run_cli`：读取线程崩溃 → 返回空字符串（0 字节）。
- 流式 `run_cli_stream`：读取线程崩溃 → 0 个 delta → 前端收到空回答。

`run_cli` 里那句「返回码非 0 且无输出才报错」也因此不触发（子进程本身退出码为 0，只是输出被解码错误吞掉），错误被静默。

## 修复

给两处 subprocess 调用显式指定 `encoding="utf-8", errors="replace"`，与各 CLI 的实际输出编码一致，且不随宿主机 locale 变化。`errors="replace"` 兜底避免个别非法字节再次导致整段丢失。

```diff
     proc = subprocess.run(
         [bin_path, *args],
         input=stdin_payload,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         cwd=tmpdir,
         env=env,
         timeout=_CLI_TIMEOUT_S,
     )
```

```diff
     proc = subprocess.Popen(
         [bin_path, *args], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL, cwd=tmpdir, env=env, text=True, bufsize=1,
+        encoding="utf-8", errors="replace",
     )
```

## 验证

在中文 Windows 11（Python 3.11）上，修复前后各跑一次真实链路（前端请求格式 → `POST /api/chat` provider=`cli-claude` → cli_runtime → 本机 `claude` CLI）：

- **修复前**：HTTP 200，但 0 个 delta、答案 0 字（后台线程抛 GBK 解码异常）。
- **修复后**：HTTP 200，47 个 delta、约 1386 字，正常流式返回「拆板块」分析。

对非中文 / UTF-8 locale 环境无行为变化（本就期望 UTF-8）。
