### PR TITLE
fix(intel): 保留资讯提炼任务状态

### DIFF
--- a/frontend/src/lib/intelDigestStore.ts
+++ b/frontend/src/lib/intelDigestStore.ts
@@ -1,0 +1,167 @@
+import { useSyncExternalStore } from "react";
+import { ApiError, type Industry } from "@/lib/api";
+import { chatStream, hasLlm } from "@/lib/llm";
+
+export interface Digest {
+  loading?: boolean;
+  text?: string;
+  err?: string;
+  needKey?: boolean;
+}
+
+export interface BulkDigestState {
+  running: boolean;
+  done: number;
+  total: number;
+}
+
+interface IntelDigestSnapshot {
+  digests: Record<string, Digest>;
+  bulk: BulkDigestState;
+}
+
+const idleBulk: BulkDigestState = { running: false, done: 0, total: 0 };
+let snapshot: IntelDigestSnapshot = { digests: {}, bulk: idleBulk };
+let bulkJob: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+/**
+ * 订阅资讯提炼状态变化。
+ *
+ * Args:
+ *   listener: React 外部 store 更新监听函数。
+ *
+ * Returns:
+ *   取消订阅函数。
+ */
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * 获取当前资讯提炼快照。
+ *
+ * Returns:
+ *   当前的赛道要点和批量任务进度。
+ */
+function getSnapshot() {
+  return snapshot;
+}
+
+/**
+ * 写入新的资讯提炼快照并通知页面。
+ *
+ * Args:
+ *   next: 下一个提炼状态快照。
+ */
+function commit(next: IntelDigestSnapshot) {
+  snapshot = next;
+  listeners.forEach((listener) => listener());
+}
+
+/**
+ * 更新单个赛道的提炼结果。
+ *
+ * Args:
+ *   key: 赛道唯一标识。
+ *   digest: 该赛道当前的提炼状态。
+ */
+function setDigest(key: string, digest: Digest) {
+  commit({ ...snapshot, digests: { ...snapshot.digests, [key]: digest } });
+}
+
+/**
+ * 更新一键提炼的整体进度。
+ *
+ * Args:
+ *   bulk: 新的批量提炼状态。
+ */
+function setBulk(bulk: BulkDigestState) {
+  commit({ ...snapshot, bulk });
+}
+
+/**
+ * 拼出赛道资讯提炼提示词。
+ *
+ * Args:
+ *   industry: 当前要提炼的赛道资讯。
+ *
+ * Returns:
+ *   可直接发送给 AI 的用户提示词。
+ */
+function buildPrompt(industry: Industry) {
+  const ctx = industry.items.slice(0, 25).map((item) => `[${item.time}] ${item.source}｜${item.zh || item.title}`).join("\n");
+  return (
+    `以下是「${industry.name}」赛道近期资讯。请提炼「今日要点」3-5 条：每条一句话（≤40 字），` +
+    `只客观陈述重要事件 / 趋势，不推荐标的、不预测涨跌、不构成建议。直接用「- 」列点，不要多余前后缀。\n\n${ctx}`
+  );
+}
+
+/**
+ * 在组件外执行单个赛道要点提炼。
+ *
+ * Args:
+ *   industry: 当前要提炼的赛道。
+ */
+export async function generateIndustryDigest(industry: Industry) {
+  if (!hasLlm()) {
+    setDigest(industry.key, { needKey: true });
+    return;
+  }
+
+  setDigest(industry.key, { loading: true });
+  const prompt = buildPrompt(industry);
+  let acc = "";
+  try {
+    await chatStream([{ role: "user", content: prompt }], `${industry.name}赛道资讯`, {
+      onDelta: (text) => {
+        acc += text;
+        setDigest(industry.key, { text: acc });
+      },
+    });
+    if (!acc) setDigest(industry.key, { err: "生成结果为空" });
+  } catch (error) {
+    setDigest(industry.key, { err: error instanceof ApiError ? error.message : "生成失败" });
+  }
+}
+
+/**
+ * 在组件外串行执行全部赛道要点提炼。
+ *
+ * Args:
+ *   industries: 当前资讯雷达返回的全部赛道。
+ *   currentIndustry: 未配置 AI 时用于展示接入提示的当前赛道。
+ */
+export function generateAllIndustryDigests(industries: Industry[], currentIndustry?: Industry) {
+  if (!hasLlm()) {
+    if (currentIndustry) setDigest(currentIndustry.key, { needKey: true });
+    return Promise.resolve();
+  }
+  if (bulkJob) return bulkJob;
+
+  const targets = industries.filter((industry) => industry.items.length > 0);
+  setBulk({ running: true, done: 0, total: targets.length });
+  bulkJob = (async () => {
+    try {
+      for (const industry of targets) {
+        await generateIndustryDigest(industry);
+        setBulk({ ...snapshot.bulk, done: snapshot.bulk.done + 1 });
+      }
+    } finally {
+      setBulk({ ...snapshot.bulk, running: false });
+      bulkJob = null;
+    }
+  })();
+  return bulkJob;
+}
+
+/**
+ * 在 React 组件中读取资讯提炼状态。
+ *
+ * Returns:
+ *   当前的赛道要点和批量任务进度。
+ */
+export function useIntelDigestStore() {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/frontend/src/pages/Intel.tsx
+++ b/frontend/src/pages/Intel.tsx
@@ -8,8 +8,8 @@ import { GlassCard } from "@/components/ui/GlassCard";
 import { Disclaimer } from "@/components/ui/Disclaimer";
 import { SaveNoteButton } from "@/components/ui/SaveNoteButton";
 import { api, ApiError, type RadarData, type Industry, type Announcement, type NewsItem } from "@/lib/api";
+import { generateAllIndustryDigests, generateIndustryDigest, useIntelDigestStore } from "@/lib/intelDigestStore";
 import { loadWatch } from "@/lib/watchlist";
-import { hasLlm, chatStream } from "@/lib/llm";
 import { cn } from "@/lib/utils";
 
 const TABS = [
@@ -19,15 +19,12 @@ const TABS = [
   { key: "investment-news", label: "Investment News", icon: Rss, integrated: true, desc: "12 赛道全球公开 RSS 资讯（集成自 investment-news 仓库）" },
 ];
 
-interface Digest { loading?: boolean; text?: string; err?: string; needKey?: boolean }
-
 function InvestmentNewsPanel() {
   const [data, setData] = useState<RadarData | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [active, setActive] = useState("ai");
   const [refreshing, setRefreshing] = useState(false);
-  const [digests, setDigests] = useState<Record<string, Digest>>({});
-  const [bulk, setBulk] = useState<{ running: boolean; done: number; total: number }>({ running: false, done: 0, total: 0 });
+  const { digests, bulk } = useIntelDigestStore();
 
   useEffect(() => {
     api.radar().then(setData).catch((e) => setErr(e instanceof ApiError ? e.message : "加载失败"));
@@ -44,34 +41,21 @@ function InvestmentNewsPanel() {
   const cur = industries.find((i) => i.key === active) || industries[0];
   const hasData = !!data?.generated_at;
 
-  const genDigest = async (ind: Industry) => {
-    if (!hasLlm()) { setDigests((d) => ({ ...d, [ind.key]: { needKey: true } })); return; }
-    setDigests((d) => ({ ...d, [ind.key]: { loading: true } }));
-    const ctx = ind.items.slice(0, 25).map((it) => `[${it.time}] ${it.source}｜${it.zh || it.title}`).join("\n");
-    const prompt =
-      `以下是「${ind.name}」赛道近期资讯。请提炼「今日要点」3-5 条：每条一句话（≤40 字），` +
-      `只客观陈述重要事件 / 趋势，不推荐标的、不预测涨跌、不构成建议。直接用「- 」列点，不要多余前后缀。\n\n${ctx}`;
-    try {
-      let acc = "";
-      await chatStream([{ role: "user", content: prompt }], `${ind.name}赛道资讯`, {
-        onDelta: (t) => { acc += t; setDigests((d) => ({ ...d, [ind.key]: { text: acc } })); },
-      });
-    } catch (e) {
-      setDigests((d) => ({ ...d, [ind.key]: { err: e instanceof ApiError ? e.message : "生成失败" } }));
-    }
-  };
+  /**
+   * 生成当前赛道的今日要点。
+   *
+   * Args:
+   *   ind: 当前要提炼的赛道。
+   */
+  const genDigest = (ind: Industry) => generateIndustryDigest(ind);
 
-  // 一键提炼全部赛道要点（串行，带进度；单赛道按需的按钮仍保留）
-  const genAll = async () => {
-    if (!hasLlm()) { if (cur) setDigests((d) => ({ ...d, [cur.key]: { needKey: true } })); return; }
-    const targets = industries.filter((i) => i.items.length > 0);
-    setBulk({ running: true, done: 0, total: targets.length });
-    for (const ind of targets) {
-      await genDigest(ind);
-      setBulk((b) => ({ ...b, done: b.done + 1 }));
-    }
-    setBulk((b) => ({ ...b, running: false }));
-  };
+  /**
+   * 一键提炼全部赛道要点。
+   *
+   * Returns:
+   *   页面外批量任务的 Promise，切换界面后仍由 store 继续保存进度。
+   */
+  const genAll = () => generateAllIndustryDigests(industries, cur);
 
   const dg = cur ? digests[cur.key] : undefined;
 


### PR DESCRIPTION
## 变更内容

- 将资讯雷达的一键提炼任务状态从组件内 useState 移到页面外 store
- 修复切换 tab / 路由后再返回时，批量提炼进度和已生成要点丢失的问题
- 防止重复点击在批量任务未完成时启动第二批请求

## 根因

InvestmentNewsPanel 之前把 digests 和 bulk 都保存在组件内 useState 中。切换界面会卸载组件，再回来时状态被重置，而原异步提炼仍绑定旧组件实例，导致用户看到之前提交的一键提炼状态消失。

## 验证

- npm run build

## 备注

本 PR 仅包含前端代码改动，不包含 AGENTS.md 或测试文件。