### PR TITLE
fix: use IPv4 loopback for Vite proxy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ import path from "path";
 // Phase 1 为纯前端空壳，后端未接时前端仍可独立跑（接口调用做了降级）。
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const apiTarget = env.VITE_API_URL || "http://localhost:8900";
+  const apiTarget = env.VITE_API_URL || "http://127.0.0.1:8900";
 
   return {
     plugins: [react()],


### PR DESCRIPTION
## Summary
- Use 127.0.0.1 as the default Vite API proxy target instead of localhost.
- Avoid ECONNREFUSED ::1:8900 when the backend listens on the IPv4 loopback address.
- Keep VITE_API_URL support for custom backend targets.

## Test Plan
- npm run build

Fixes #8