### PR TITLE
Add Codex app CLI lookup path

### DIFF
--- a/backend/cli_runtime.py
+++ b/backend/cli_runtime.py
@@ -47,6 +47,7 @@ _CLI_DEFS: dict[str, dict] = {
 
 _EXTRA_PATH_DIRS = [
     "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin",
+    "/Applications/Codex.app/Contents/Resources",
     str(Path.home() / ".local/bin"), str(Path.home() / ".npm-global/bin"),
     str(Path.home() / ".bun/bin"), str(Path.home() / ".deno/bin"),
     str(Path.home() / ".yarn/bin"),


### PR DESCRIPTION
## Summary
- add the macOS Codex app bundled CLI path to the fallback search directories
- allow subscription integration to detect Codex when it is installed as /Applications/Codex.app

## Test
- python3 - <<'PY'
import sys
sys.path.insert(0, 'backend')
import cli_runtime
assert cli_runtime.detect_cli('codex')
print('detect_cli codex ok')
PY