### PR TITLE
feat(deploy): 添加 Docker Compose 部署支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.env
+.env.*
+**/.venv
+**/node_modules
+**/__pycache__
+**/.cache
+**/.pytest_cache
+frontend/dist
+frontend/tsconfig.tsbuildinfo
+data
+docs
+a-stock-data
+global-stock-data
+backend/tests
+*.log

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Docker Compose configuration. Copy this file to .env before deploying.
+# The default bind only exposes the app on this machine.
+VR_BIND_ADDRESS=127.0.0.1
+VR_PORT=8080
+
+# Persistent user data (portfolio and uploaded reports). This path is relative
+# to docker-compose.yml unless you set an absolute host path.
+VR_DATA_DIR_HOST=./data
+
+# Backend security. The default CORS value is appropriate while the app is
+# loopback-only. If you bind it publicly, set a strong VR_API_KEY and use it in
+# the Settings page after opening the app.
+VR_ALLOW_ORIGINS=*
+VR_API_KEY=
+
+# Set to 1 only when this host needs its system proxy to access data sources.
+VR_DATA_PROXY=

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ VibeResearch-专业化建议.md
 my-watchlist.json
 portfolio.json
 public/user-data/
+# Docker Compose 默认持久化目录（持仓 / 研报，绝不进仓库）
+data/
 
 # ── 密钥 / 环境（绝不进仓库） ──────────────────────────────────────
 .env

--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ cd frontend && npm install && npm run dev
 # 浏览器打开 http://localhost:5899
 ```
 
+### Docker Compose 部署
+
+需要 Docker Engine（含 Docker Compose）。Compose 会构建前端与后端，浏览器和 API 同源访问，后端不会直接暴露到宿主机。
+
+```bash
+cp .env.example .env
+docker compose up -d --build
+# 浏览器打开 http://127.0.0.1:8080
+```
+
+持仓和上传的研报会持久化在 `VR_DATA_DIR_HOST`（默认 `./data/`），升级时直接再次执行 `docker compose up -d --build` 即可；停止服务不删除数据。查看状态和日志：
+
+```bash
+docker compose ps
+docker compose logs -f
+```
+
+默认只监听本机回环地址，适合个人部署。如需局域网或公网访问，请在 `.env` 中将 `VR_BIND_ADDRESS` 改为 `0.0.0.0`，并设置高强度 `VR_API_KEY`；打开网页后，在「接入 AI」页底部填入同一个后端访问密钥。通过公网反向代理时，也应将 `VR_ALLOW_ORIGINS` 收紧为你的站点域名。
+
 ## 🔌 接入 AI
 
 在「接入 AI」页配置一次，全站的「问 AI / 复盘 / 今日要点」就都用你自己的模型。**分析都由你的模型给出，本产品不校准、无倾向。** 三种方式：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: docker/backend.Dockerfile
+    restart: unless-stopped
+    environment:
+      VR_DATA_DIR: /data
+      VR_REPORTS_DIR: /data/myreports
+      VR_ALLOW_ORIGINS: ${VR_ALLOW_ORIGINS:-*}
+      VR_API_KEY: ${VR_API_KEY:-}
+      VR_DATA_PROXY: ${VR_DATA_PROXY:-}
+    volumes:
+      - ${VR_DATA_DIR_HOST:-./data}:/data
+    expose:
+      - "8900"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8900/api/health')"
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/frontend.Dockerfile
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "${VR_BIND_ADDRESS:-127.0.0.1}:${VR_PORT:-8080}:80"

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ ./
+
+EXPOSE 8900
+
+CMD ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8900"]

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # 单个研报上限 25 MiB，base64 JSON 上传后的请求约 33 MiB。
+    client_max_body_size 35m;
+
+    location /api/ {
+        proxy_pass http://backend:8900;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # /api/chat 是 NDJSON 流；关闭缓冲才能把回答实时转发给浏览器。
+        proxy_buffering off;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## 变更内容

为项目添加 Docker Compose 一键部署支持（8 个文件，+147 行）：

- **`docker-compose.yml`** — backend + frontend 双服务编排；backend 带健康检查（`/api/health`），frontend 依赖 backend healthy 后启动
- **`docker/backend.Dockerfile`** / **`docker/frontend.Dockerfile`** — 后端 Python / 前端构建 + nginx 镜像
- **`docker/nginx.conf`** — 前端静态资源 + `/api` 反向代理到 backend:8900
- **`.env.example`** — 部署配置示例（绑定地址/端口、数据目录、CORS、API Key、数据源代理）
- **`.dockerignore`** / **`.gitignore`** — 构建上下文与数据目录忽略规则
- **README** — 补充 Docker Compose 部署说明
