### PR TITLE
Render Markdown in Ask AI responses

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test tests/*.test.mjs",
     "build": "tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/frontend/src/components/ui/AskAiButton.tsx
+++ b/frontend/src/components/ui/AskAiButton.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Sparkles, X, Settings, Send, Loader2, Wrench, AlertCircle } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
 import { hasLlm, chatStream, type ChatMsg } from "@/lib/llm";
 import { ApiError } from "@/lib/api";
@@ -159,7 +161,13 @@ export function AskAiButton({ context, suggestions = [], label = "问 AI" }: Pro
                             ))}
                           </div>
                         )}
-                        <p className="whitespace-pre-wrap">{m.content}</p>
+                        {m.role === "assistant" ? (
+                          <div className="prose prose-sm prose-invert max-w-none break-words text-foreground">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.content}</ReactMarkdown>
+                          </div>
+                        ) : (
+                          <p className="whitespace-pre-wrap break-words">{m.content}</p>
+                        )}
                         {m.role === "assistant" && m.content && !(loading && i === msgs.length - 1) && (
                           <div className="mt-1.5"><SaveNoteButton kind="问AI" title={`问 AI · ${msgs[i - 1]?.content?.slice(0, 24) || "对话"}`} content={m.content} /></div>
                         )}

--- a/frontend/tests/ask-ai-markdown.test.mjs
+++ b/frontend/tests/ask-ai-markdown.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+test("the existing markdown stack renders common AI response formatting", () => {
+  const markdown = "## Risk\n\n- **High volatility**\n\n> Verify independently";
+  const html = renderToStaticMarkup(
+    React.createElement(ReactMarkdown, { remarkPlugins: [remarkGfm] }, markdown),
+  );
+
+  assert.match(html, /<h2>Risk<\/h2>/);
+  assert.match(html, /<ul>/);
+  assert.match(html, /<strong>High volatility<\/strong>/);
+  assert.match(html, /<blockquote>/);
+});
+
+test("Ask AI renders assistant messages with the markdown stack", async () => {
+  const source = await readFile(
+    new URL("../src/components/ui/AskAiButton.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /import ReactMarkdown from "react-markdown";/);
+  assert.match(source, /import remarkGfm from "remark-gfm";/);
+  assert.match(
+    source,
+    /m\.role === "assistant"\s*\?\s*\(\s*<div className="prose[^"]*">\s*<ReactMarkdown remarkPlugins=\{\[remarkGfm\]\}>\{m\.content\}<\/ReactMarkdown>\s*<\/div>/s,
+  );
+});


### PR DESCRIPTION
## Summary
- Render assistant responses in the Ask AI panel with the repository's existing ReactMarkdown and GFM stack.
- Keep user prompts as literal text and preserve ReactMarkdown's safe default with raw HTML disabled.
- Add a lightweight regression test and npm test script covering headings, emphasis, lists, blockquotes, and the Ask AI integration.

## Test Plan
- [x] npm test
- [x] npm run build
- [x] Verified in Chrome on /portfolio that AI Markdown renders as structured content