### PR TITLE
feat: Docker 构建 + docker compose 一键启动 + CI 一键发布镜像到 GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Docker 构建上下文排除（根目录 compose build 用；镜像里只需要 backend/ 与 frontend/）
+**/.git
+**/.venv
+**/node_modules
+**/__pycache__
+**/.pytest_cache
+**/.cache
+**/*.pyc
+.env
+dist
+build
+a-stock-data
+global-stock-data
+docs
+assets
+*.log
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Vibe-Research · Docker Compose 可选配置。
+# 用法：复制为 .env（docker compose 会自动读取），再 docker compose up -d --build。
+# 本地自托管：全部留空即可（开箱开放）。
+
+# ── 安全（公网部署必设） ─────────────────────────────────────────────
+# 后端鉴权 key。一旦设置，所有 /api/*（除 /api/health）都需带 Authorization: Bearer <key>。
+# 本地留空=开放；公网部署务必设一个强随机值（否则别人能读你的持仓、调你的后端）：
+#   VR_API_KEY=$(openssl rand -hex 32)
+VR_API_KEY=
+
+# CORS 白名单，逗号分隔。默认 "*"（放开，适合本地）。公网部署收紧成你的前端域名：
+#   VR_ALLOW_ORIGINS=https://your-frontend-host
+VR_ALLOW_ORIGINS=*

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,114 @@
+# Vibe-Research · CI/CD：构建并发布前后端镜像到 GHCR（ghcr.io）。
+#
+# 触发方式：
+#   1. 手动一键：GitHub Actions 页面 → Run workflow
+#   2. 打 v* 格式 tag（如 v0.4.0）自动发布正式版
+#
+# 产物（多架构 linux/amd64 + linux/arm64）：
+#   ghcr.io/<owner>/vibe-research-backend
+#   ghcr.io/<owner>/vibe-research-frontend
+#
+# 依赖：本仓库自带 Docker 文件（backend/Dockerfile、frontend/Dockerfile），开箱即用。
+name: Build & Publish Docker Images
+
+on:
+  workflow_dispatch: # 手动「一键发布」
+  push:
+    tags:
+      - "v*" # 打 v0.4.0 这类 tag 时自动发布
+
+permissions:
+  contents: read
+  packages: write # 推送 GHCR 镜像需要
+
+jobs:
+  test:
+    name: Backend offline tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+      - name: Install test deps
+        run: |
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+      - name: Run offline tests
+        working-directory: backend
+        # 离线单测 + API 校验：快、稳、无需联网（联网 live 用例留给出包前人工跑）
+        run: pytest -m "not live" -q
+
+  publish:
+    name: Build & push images to GHCR
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # GHCR 鉴权：用 GITHUB_TOKEN，零自定义 secret
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 镜像 tag 方案（docker/metadata-action）：
+      #   - main 上跑（手动触发）：latest + sha-<短sha>
+      #   - v* tag 上跑：      <版本号> + <主.次> + latest + sha-<短sha>
+      - name: Compute backend tags
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vibe-research-backend
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=sha-{{sha}},enable=true
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Compute frontend tags
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vibe-research-frontend
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=sha-{{sha}},enable=true
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      # 构建上下文 = 仓库根（与 docker compose build 一致），镜像里只需 backend/ 与 frontend/
+      - name: Build & push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,8 +26,8 @@ jobs:
     name: Backend offline tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -47,17 +47,17 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # GHCR 鉴权：用 GITHUB_TOKEN，零自定义 secret
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
       #   - v* tag 上跑：      <版本号> + <主.次> + latest + sha-<短sha>
       - name: Compute backend tags
         id: meta-backend
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/vibe-research-backend
           tags: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Compute frontend tags
         id: meta-frontend
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/vibe-research-frontend
           tags: |
@@ -90,7 +90,7 @@ jobs:
 
       # 构建上下文 = 仓库根（与 docker compose build 一致），镜像里只需 backend/ 与 frontend/
       - name: Build & push backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: backend/Dockerfile
@@ -102,7 +102,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build & push frontend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: frontend/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ frontend/tsconfig.tsbuildinfo
 
 # ── 编辑器 / 系统 / 工具 ──────────────────────────────────────────
 **/.claude/
+**/.zcode/
 .DS_Store
 *.log
 .vscode/

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ cd frontend && npm install && npm run dev
 # 浏览器打开 http://localhost:5899
 ```
 
+### Docker 部署（一条命令起整个应用）
+
+不想装 Python / Node 环境？有 Docker 就行。仓库自带 `Dockerfile` + `compose.yaml`，一条命令构建并启动前后端：
+
+```bash
+docker compose up -d --build
+# 浏览器打开 http://localhost:5899
+```
+
+说明：
+
+- **两个容器**：`backend`（Python + FastAPI :8900）与 `frontend`（nginx 托管前端静态产物 :80，并反代 `/api` 到 backend，对外暴露 `:5899`）。所有 API 走相对路径 `/api`，无需改任何配置。
+- **数据持久化**：持仓 / 已清仓 / 上传的研报写在 Docker 命名卷 `vibe-data`（容器内 `VR_DATA_DIR=/data`），`docker compose down` 或重建容器都不丢；要彻底清空用 `docker compose down -v`。
+- **可选配置**：复制 [`.env.example`](.env.example) 为 `.env`（compose 自动读取），按需设置 `VR_API_KEY`（公网部署必设）与 `VR_ALLOW_ORIGINS`。
+- 也想直接打后端 API？`:8900` 已一并映射到宿主机。
+- **体积说明**：镜像只含 `backend/` 与 `frontend/` 运行所需代码；根目录的 `a-stock-data/`、`global-stock-data/` 是给本地 agent 用的数据工具箱，**不打包进容器**（后端数据层已内置同源实现，功能不受影响）。
+
 ## 接入 AI
 
 在「接入 AI」页配置一次，全站的「问 AI / 复盘 / 今日要点」就都用你自己的模型。**分析都由你的模型给出，本产品不校准、无倾向。** 三种方式：

--- a/README.md
+++ b/README.md
@@ -141,20 +141,41 @@ cd frontend && npm install && npm run dev
 
 ### Docker 部署（一条命令起整个应用）
 
-不想装 Python / Node 环境？有 Docker 就行。仓库自带 `Dockerfile` + `compose.yaml`，一条命令构建并启动前后端：
+不想装 Python / Node 环境？有 Docker 就行。**两种方式按需选：**
+
+**① 复制即部署（免 clone、免构建）** —— 只要机器有 Docker，复制 [`docker-compose.yml`](docker-compose.yml) 这一个文件到任意目录：
 
 ```bash
+docker compose up -d
+# 浏览器打开 http://localhost:5899
+```
+
+> 前提是镜像已发布（见下文「一键发布镜像」）。想先自己试？把文件里镜像地址的 `simonlin1212` 改成你的 GitHub 用户名，在你自己的仓库跑一次发布即可。
+
+**② 本地构建（开发 / 想跑最新源码）** —— 拉下仓库自己打镜像：
+
+```bash
+git clone https://github.com/simonlin1212/Vibe-Research && cd Vibe-Research
 docker compose up -d --build
 # 浏览器打开 http://localhost:5899
 ```
 
 说明：
 
-- **两个容器**：`backend`（Python + FastAPI :8900）与 `frontend`（nginx 托管前端静态产物 :80，并反代 `/api` 到 backend，对外暴露 `:5899`）。所有 API 走相对路径 `/api`，无需改任何配置。
+- **两个 compose 文件**：`docker-compose.yml` 是**部署版**（`image:` 直接拉 GHCR 现成镜像，复制即用）；`compose.yaml` 是**开发版**（`build:` 本地构建，就是方式②用的）。
 - **数据持久化**：持仓 / 已清仓 / 上传的研报写在 Docker 命名卷 `vibe-data`（容器内 `VR_DATA_DIR=/data`），`docker compose down` 或重建容器都不丢；要彻底清空用 `docker compose down -v`。
 - **可选配置**：复制 [`.env.example`](.env.example) 为 `.env`（compose 自动读取），按需设置 `VR_API_KEY`（公网部署必设）与 `VR_ALLOW_ORIGINS`。
 - 也想直接打后端 API？`:8900` 已一并映射到宿主机。
-- **体积说明**：镜像只含 `backend/` 与 `frontend/` 运行所需代码；根目录的 `a-stock-data/`、`global-stock-data/` 是给本地 agent 用的数据工具箱，**不打包进容器**（后端数据层已内置同源实现，功能不受影响）。
+- **体积说明**：镜像只含 `backend/` 与 `frontend/` 运行所需代码；根目录的 `a-stock-data/`、`global-stock-data/` 是给本地 agent 用的数据工具箱，**不打包进镜像**（后端数据层已内置同源实现，功能不受影响）。
+
+### 一键发布镜像（CI/CD）
+
+合并后仓库自带 GitHub Actions，**一键发布前后端镜像到 GHCR（ghcr.io）**，多架构 `linux/amd64 + linux/arm64`：
+
+- **手动一键**：仓库 Actions 页 → Build & Publish Docker Images → **Run workflow**
+- **打 tag 自动**：`git tag v0.4.0 && git push --tags`
+
+产物：`ghcr.io/simonlin1212/vibe-research-backend` / `-frontend`（公开镜像，免登录拉取）。发布后上面的「复制即部署」即可直接用。
 
 ## 接入 AI
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ cd frontend && npm install && npm run dev
 
 不想装 Python / Node 环境？有 Docker 就行。**两种方式按需选：**
 
-**① 复制即部署（免 clone、免构建）** —— 只要机器有 Docker，复制 [`docker-compose.yml`](docker-compose.yml) 这一个文件到任意目录：
+**① 复制即部署（免 clone、免构建）** —— 只要机器有 Docker，复制 [`compose.deploy.yaml`](compose.deploy.yaml) 这一个文件到任意目录：
 
 ```bash
 docker compose up -d
@@ -162,7 +162,7 @@ docker compose up -d --build
 
 说明：
 
-- **两个 compose 文件**：`docker-compose.yml` 是**部署版**（`image:` 直接拉 GHCR 现成镜像，复制即用）；`compose.yaml` 是**开发版**（`build:` 本地构建，就是方式②用的）。
+- **两个 compose 文件**：仓库根目录默认用 `compose.yaml`（**开发版**，`build:` 本地构建，就是方式②用的）；`compose.deploy.yaml` 是**部署版**（`image:` 直接拉 GHCR 现成镜像，复制即用）。部署版独立命名，避免被 `compose.yaml` 的默认优先级遮蔽；在仓库内跑部署版用 `docker compose -f compose.deploy.yaml up -d`。
 - **数据持久化**：持仓 / 已清仓 / 上传的研报写在 Docker 命名卷 `vibe-data`（容器内 `VR_DATA_DIR=/data`），`docker compose down` 或重建容器都不丢；要彻底清空用 `docker compose down -v`。
 - **可选配置**：复制 [`.env.example`](.env.example) 为 `.env`（compose 自动读取），按需设置 `VR_API_KEY`（公网部署必设）与 `VR_ALLOW_ORIGINS`。
 - 也想直接打后端 API？`:8900` 已一并映射到宿主机。

--- a/README_en.md
+++ b/README_en.md
@@ -135,6 +135,23 @@ cd frontend && npm install && npm run dev
 # Open http://localhost:5899
 ```
 
+### Docker (start the whole app with one command)
+
+No Python / Node setup needed — just Docker. The repo ships a `Dockerfile` + `compose.yaml`:
+
+```bash
+docker compose up -d --build
+# Open http://localhost:5899
+```
+
+Notes:
+
+- **Two containers**: `backend` (Python + FastAPI :8900) and `frontend` (nginx serving the built SPA on :80, proxying `/api` to backend, exposed as `:5899`). All API calls use the relative `/api` prefix — nothing to configure.
+- **Data persistence**: portfolio / closed positions / uploaded reports are stored in the named volume `vibe-data` (container `VR_DATA_DIR=/data`), so `docker compose down` or container rebuilds don't lose data; wipe everything with `docker compose down -v`.
+- **Optional config**: copy [`.env.example`](.env.example) to `.env` (compose reads it automatically) to set `VR_API_KEY` (required for public deployment) and `VR_ALLOW_ORIGINS`.
+- Port `:8900` is also mapped to the host if you want to hit the API directly.
+- **Image footprint**: the image only contains `backend/` and `frontend/`; the root `a-stock-data/` and `global-stock-data/` toolkits are for local agents and are **not packaged into the image** (the backend data layer already ships the same implementations).
+
 ## Bring Your Own AI
 
 Configure once on the "Bring your AI" page and every AI feature across the dashboard uses your model. **All analysis comes from your model — this project does not tune or bias it.** Three options:

--- a/README_en.md
+++ b/README_en.md
@@ -139,7 +139,7 @@ cd frontend && npm install && npm run dev
 
 No Python / Node setup needed — just Docker. **Pick one of two ways:**
 
-**① Copy-and-run deployment (no clone, no build)** — if you have Docker, copy this one file [`docker-compose.yml`](docker-compose.yml) to any directory:
+**① Copy-and-run deployment (no clone, no build)** — if you have Docker, copy this one file [`compose.deploy.yaml`](compose.deploy.yaml) to any directory:
 
 ```bash
 docker compose up -d
@@ -158,7 +158,7 @@ docker compose up -d --build
 
 Notes:
 
-- **Two compose files**: `docker-compose.yml` is the **deployment** one (`image:` pulls ready-made GHCR images, copy-and-run); `compose.yaml` is the **development** one (`build:` local build, used by option ②).
+- **Two compose files**: `compose.yaml` is the default in the repo root — the **development** one (`build:` local build, used by option ②). `compose.deploy.yaml` is the **deployment** one (`image:` pulls ready-made GHCR images, copy-and-run); it has its own name so the `compose.yaml` default precedence doesn't silently shadow it — run it from the repo with `docker compose -f compose.deploy.yaml up -d`.
 - **Data persistence**: portfolio / closed positions / uploaded reports are stored in the named volume `vibe-data` (container `VR_DATA_DIR=/data`), so `docker compose down` or container rebuilds don't lose data; wipe everything with `docker compose down -v`.
 - **Optional config**: copy [`.env.example`](.env.example) to `.env` (compose reads it automatically) to set `VR_API_KEY` (required for public deployment) and `VR_ALLOW_ORIGINS`.
 - Port `:8900` is also mapped to the host if you want to hit the API directly.

--- a/README_en.md
+++ b/README_en.md
@@ -137,20 +137,41 @@ cd frontend && npm install && npm run dev
 
 ### Docker (start the whole app with one command)
 
-No Python / Node setup needed — just Docker. The repo ships a `Dockerfile` + `compose.yaml`:
+No Python / Node setup needed — just Docker. **Pick one of two ways:**
+
+**① Copy-and-run deployment (no clone, no build)** — if you have Docker, copy this one file [`docker-compose.yml`](docker-compose.yml) to any directory:
 
 ```bash
+docker compose up -d
+# Open http://localhost:5899
+```
+
+> Prerequisite: images must be published (see "One-click image publishing" below). Want to try it yourself first? Replace `simonlin1212` in the image addresses with your GitHub username and run the publish workflow in your own repo.
+
+**② Build locally (development / running latest source)** — clone the repo and build the images:
+
+```bash
+git clone https://github.com/simonlin1212/Vibe-Research && cd Vibe-Research
 docker compose up -d --build
 # Open http://localhost:5899
 ```
 
 Notes:
 
-- **Two containers**: `backend` (Python + FastAPI :8900) and `frontend` (nginx serving the built SPA on :80, proxying `/api` to backend, exposed as `:5899`). All API calls use the relative `/api` prefix — nothing to configure.
+- **Two compose files**: `docker-compose.yml` is the **deployment** one (`image:` pulls ready-made GHCR images, copy-and-run); `compose.yaml` is the **development** one (`build:` local build, used by option ②).
 - **Data persistence**: portfolio / closed positions / uploaded reports are stored in the named volume `vibe-data` (container `VR_DATA_DIR=/data`), so `docker compose down` or container rebuilds don't lose data; wipe everything with `docker compose down -v`.
 - **Optional config**: copy [`.env.example`](.env.example) to `.env` (compose reads it automatically) to set `VR_API_KEY` (required for public deployment) and `VR_ALLOW_ORIGINS`.
 - Port `:8900` is also mapped to the host if you want to hit the API directly.
 - **Image footprint**: the image only contains `backend/` and `frontend/`; the root `a-stock-data/` and `global-stock-data/` toolkits are for local agents and are **not packaged into the image** (the backend data layer already ships the same implementations).
+
+### One-click image publishing (CI/CD)
+
+The repo ships a GitHub Actions workflow that **publishes both images to GHCR** (`ghcr.io`), multi-arch `linux/amd64 + linux/arm64`:
+
+- **Manual one-click**: repo Actions tab → Build & Publish Docker Images → **Run workflow**
+- **Auto on tag**: `git tag v0.4.0 && git push --tags`
+
+Artifacts: `ghcr.io/simonlin1212/vibe-research-backend` / `-frontend` (public, pull without login). Once published, the "copy-and-run deployment" above just works.
 
 ## Bring Your Own AI
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+# Vibe-Research 后端 —— FastAPI + A股/美股/港股数据层。
+# 构建上下文为仓库根目录（见 compose.yaml build.context），仅拷贝 backend/ 进镜像。
+FROM python:3.12-slim
+
+# pandas / numpy 编译会拖慢构建，这里不需要编译工具链（用预编译 wheel）
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app/backend
+
+# 先装依赖再拷代码：requirements 变化频率远低于源码，可复用依赖层缓存
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ ./
+
+EXPOSE 8900
+
+# 用户私有数据（持仓 / 研报）写 VR_DATA_DIR 挂载卷，见 compose.yaml
+CMD ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8900"]

--- a/compose.deploy.yaml
+++ b/compose.deploy.yaml
@@ -1,9 +1,15 @@
 # Vibe-Research · 部署版（复制即用，无需 clone 项目、无需本地构建）
 #
-# 用法：
-#   1. 复制本文件到任意目录（文件名叫 docker-compose.yml 或 compose.yaml 都行）
-#   2. docker compose up -d
-#   3. 浏览器打开 http://localhost:5899
+# 与 compose.yaml（开发版，本地 build）并存。为什么叫 compose.deploy.yaml：
+# Docker Compose 在根目录会自动优先用 compose.yaml，为避免部署版被静默遮蔽，
+# 部署版独立命名，需要时用 -f 显式指定。
+#
+# 用法（二选一）：
+#   1. 复制本文件到任意目录（文件名随意，docker-compose.yml 也行），然后：
+#      docker compose up -d
+#   2. 或在仓库根目录显式指定：
+#      docker compose -f compose.deploy.yaml up -d
+#   浏览器打开 http://localhost:5899
 #
 # 前提：镜像已发布到 GHCR（仓库 CI 会自动发布 ghcr.io/<owner>/vibe-research-*）。
 #       想先自己试？把下面 image 里的 `simonlin1212` 改成你自己的 GitHub 用户名，

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,46 @@
+# Vibe-Research · Docker Compose —— 一条命令起整个应用。
+#
+#   docker compose up -d --build
+#   浏览器打开 http://localhost:5899
+#
+# 可选配置（复制 .env.example 为 .env 后修改）：
+#   VR_API_KEY        公网部署务必设一个强随机值，否则别人能读你的持仓/调你的后端
+#   VR_ALLOW_ORIGINS  公网部署时收紧成你的前端域名，逗号分隔
+name: vibe-research
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    # 用户私有数据（持仓 / 已清仓 / 上传研报）写进命名卷，容器重建不丢；
+    # 默认 ~/.vibe-research/，这里改到 /data 由卷挂载。
+    environment:
+      VR_DATA_DIR: /data
+      VR_API_KEY: ${VR_API_KEY:-}
+      VR_ALLOW_ORIGINS: ${VR_ALLOW_ORIGINS:-*}
+    volumes:
+      - vibe-data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8900/api/health', timeout=3)"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    ports:
+      - "8900:8900"
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "5899:80"
+    restart: unless-stopped
+
+volumes:
+  vibe-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+# Vibe-Research · 部署版（复制即用，无需 clone 项目、无需本地构建）
+#
+# 用法：
+#   1. 复制本文件到任意目录（文件名叫 docker-compose.yml 或 compose.yaml 都行）
+#   2. docker compose up -d
+#   3. 浏览器打开 http://localhost:5899
+#
+# 前提：镜像已发布到 GHCR（仓库 CI 会自动发布 ghcr.io/<owner>/vibe-research-*）。
+#       想先自己试？把下面 image 里的 `simonlin1212` 改成你自己的 GitHub 用户名，
+#       在你自己的仓库跑一次发布 workflow 即可。
+#
+# 可选配置（可选，本地默认全留空）：
+#   VR_API_KEY        公网部署务必设一个强随机值，否则别人能读你的持仓/调你的后端
+#   VR_ALLOW_ORIGINS  公网部署时收紧成你的前端域名
+name: vibe-research
+
+services:
+  backend:
+    image: ghcr.io/simonlin1212/vibe-research-backend:latest
+    pull_policy: always # 每次 up 都拉最新镜像
+    # 用户私有数据（持仓 / 已清仓 / 上传研报）写进命名卷，重建容器不丢
+    environment:
+      VR_DATA_DIR: /data
+      VR_API_KEY: ${VR_API_KEY:-}
+      VR_ALLOW_ORIGINS: ${VR_ALLOW_ORIGINS:-*}
+    volumes:
+      - vibe-data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8900/api/health', timeout=3)"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    ports:
+      - "8900:8900"
+    restart: unless-stopped
+
+  frontend:
+    image: ghcr.io/simonlin1212/vibe-research-frontend:latest
+    pull_policy: always
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "5899:80"
+    restart: unless-stopped
+
+volumes:
+  vibe-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# Vibe-Research 前端 —— 多阶段构建。
+# 构建上下文为仓库根目录（见 compose.yaml build.context），仅把 frontend/ 送进构建上下文。
+#
+# Stage 1: 构建静态产物（node 20 LTS + npm ci 锁版本）
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+# Stage 2: nginx 托管静态产物 + 反代 /api → backend 服务（见 nginx.conf）
+FROM nginx:1.27-alpine
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,28 @@
+# Vibe-Research 前端生产容器：托管静态产物 + 反代 /api → backend 服务。
+# 前端请求全部走相对路径 /api 前缀（frontend/src/lib/api.ts），同源反代即可，无需改应用代码。
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA 路由：找不到对应文件时回退到 index.html（react-router 接管）
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # 反代后端 API。/api/debate、/api/reflect 是 NDJSON 流式响应，必须关缓冲才能实时吐字；
+    # 辩论一轮约 100 秒，读超时放宽到 5 分钟。
+    location /api/ {
+        proxy_pass http://backend:8900;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}


### PR DESCRIPTION
## 改动
新增 **Docker 构建 + docker compose 一键启动 + GitHub Actions 一键发布镜像到 GHCR**，一个 PR 全部到位：

```bash
# 本地起应用
docker compose up -d --build
# 浏览器打开 http://localhost:5899

# 一键发布镜像（GitHub Actions 页面 → Run workflow）
# 或打 v* 格式 tag 自动发布正式版：git tag v0.4.0 && git push --tags
```

### 一、Docker 构建
| 文件 | 说明 |
|---|---|
| `backend/Dockerfile` | `python:3.12-slim` + uvicorn :8900（含 akshare/mootdx/pandas 全量依赖） |
| `frontend/Dockerfile` | 多阶段构建：node:20-alpine 构建静态产物 → nginx:alpine 托管 |
| `frontend/nginx.conf` | 托管 SPA（`try_files` 路由回退）+ 反代 `/api` → backend；**NDJSON 流式响应关缓冲**（辩论/反思实时吐字）、读超时放宽到 300s |
| `compose.yaml` | backend(:8900) + frontend(:5899)；`VR_DATA_DIR=/data` 挂命名卷 `vibe-data` 持久化持仓/研报；backend healthcheck 通过后 frontend 才启动 |
| `.dockerignore` | 构建上下文瘦身（排除 `.git`/`node_modules`/`a-stock-data`/`global-stock-data` 等） |
| `.env.example` | `VR_API_KEY` / `VR_ALLOW_ORIGINS` 可选配置（公网部署必设 key） |

前端所有请求走相对路径 `/api`，nginx 同源反代即可，**零应用代码改动**。

### 二、CI 一键发布（`.github/workflows/build-and-publish.yml`）
- 触发：**手动 Run workflow**（一键发布）；**v* tag 自动**发布正式版
- 产物：`ghcr.io/<owner>/vibe-research-backend` / `-frontend`，多架构 **linux/amd64 + linux/arm64**
- 流程：后端离线单测（`pytest -m "not live"`，发布前置检查）→ buildx 多架构构建 → GHCR 推送
- 鉴权 `GITHUB_TOKEN`，**零自定义 secret**；GHCR 包默认公开，可免登录拉取
- 标签：手动触发 → `latest` + `sha-xxx`；v* tag → `<版本号>` + `<主.次>` + `latest` + `sha-xxx`

### 已验证 ✅
- Docker：`docker compose build` 两端镜像构建成功；`docker compose up` 全链路冒烟通过（页面 / SPA 路由回退 / `/api` 反代 / 真实数据接口）；后端离线单测 79 passed
- CI：在 fork `lianxin255/Vibe-Research` 上手动触发完整跑通（[run 31065007789](https://github.com/lianxin255/Vibe-Research/actions/runs/31065007789)，两个 job 均 success），并核验 GHCR 镜像双架构（amd64 + arm64）。期间修复一处：test job 需同时装 `requirements.txt`（运行依赖）+ `requirements-dev.txt`（dev 依赖），否则全新环境缺 fastapi

### 文档
README.md / README_en.md 新增「Docker 部署」小节。