### PR TITLE
feat(ci): GitHub Actions 一键发布镜像到 GHCR

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,115 @@
+# Vibe-Research · CI/CD：构建并发布前后端镜像到 GHCR（ghcr.io）。
+#
+# 触发方式：
+#   1. 手动一键：GitHub Actions 页面 → Run workflow
+#   2. 打 v* 格式 tag（如 v0.4.0）自动发布正式版
+#
+# 产物（多架构 linux/amd64 + linux/arm64）：
+#   ghcr.io/<owner>/vibe-research-backend
+#   ghcr.io/<owner>/vibe-research-frontend
+#
+# 注意：Docker 文件（backend/Dockerfile、frontend/Dockerfile、compose.yaml）由 PR #24
+#       引入，本 workflow 依赖它们 —— 需先合并 #24 再跑本 workflow。
+name: Build & Publish Docker Images
+
+on:
+  workflow_dispatch: # 手动「一键发布」
+  push:
+    tags:
+      - "v*" # 打 v0.4.0 这类 tag 时自动发布
+
+permissions:
+  contents: read
+  packages: write # 推送 GHCR 镜像需要
+
+jobs:
+  test:
+    name: Backend offline tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+      - name: Install test deps
+        run: |
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+      - name: Run offline tests
+        working-directory: backend
+        # 离线单测 + API 校验：快、稳、无需联网（联网 live 用例留给出包前人工跑）
+        run: pytest -m "not live" -q
+
+  publish:
+    name: Build & push images to GHCR
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # GHCR 鉴权：用 GITHUB_TOKEN，零自定义 secret
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 镜像 tag 方案（docker/metadata-action）：
+      #   - main 上跑（手动触发）：latest + sha-<短sha>
+      #   - v* tag 上跑：      <版本号> + <主.次> + latest + sha-<短sha>
+      - name: Compute backend tags
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vibe-research-backend
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=sha-{{sha}},enable=true
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Compute frontend tags
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vibe-research-frontend
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=sha-{{sha}},enable=true
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      # 构建上下文 = 仓库根（与 docker compose build 一致），镜像里只需 backend/ 与 frontend/
+      - name: Build & push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## 改动
新增 GitHub Actions workflow，**一键发布前后端镜像到 GHCR**（`ghcr.io`），多架构 `linux/amd64 + linux/arm64`。

```bash
# 一键发布（GitHub Actions 页面 → Run workflow）
# 或打 v* 格式 tag 自动发布正式版（如 git tag v0.4.0 && git push --tags）
```

### 产物
| 镜像 | 来源 |
|---|---|
| `ghcr.io/<owner>/vibe-research-backend` | `backend/Dockerfile` |
| `ghcr.io/<owner>/vibe-research-frontend` | `frontend/Dockerfile` |

- 手动触发（main 上）：`latest` + `sha-<短sha>` 标签
- v* tag 触发：`<版本号>` + `<主.次>` + `latest` + `sha-<短sha>`
- 鉴权用 `GITHUB_TOKEN`（`packages: write`），**零自定义 secret**；GHCR 包默认公开，可免登录拉取

### 流程
`Backend offline tests`（pytest `-m "not live"`，发布前置检查）→ `Build & push images to GHCR`（setup-qemu + buildx 多架构构建 + 推送，GHA 层缓存加速）

### 已在 fork 真实验证 ✅
- 在 fork `lianxin255/Vibe-Research` 上手动触发完整跑通：[run 31065007789](https://github.com/lianxin255/Vibe-Research/actions/runs/31065007789) 两个 job 均 success
- 镜像已推送并核验双架构：`ghcr.io/lianxin255/vibe-research-backend|frontend:sha-2e34ff6`（linux/amd64 + linux/arm64）
- 期间修复过一处：test job 需同时装 `requirements.txt`（运行依赖）+ `requirements-dev.txt`（开发依赖），否则全新环境缺 fastapi

### ⚠️ 合并顺序
本 workflow 的 `publish` job 依赖 **#24（Docker 构建 + docker compose）** 引入的 `backend/Dockerfile`、`frontend/Dockerfile`——**请先合并 #24，再合并本 PR**，否则发布时找不到 Dockerfile。

### 文档
README 的「镜像发布」使用说明待 #24 合并后一并补齐（本 PR 不动 README，避免与 #24 的改动冲突）。