### PR TITLE
fix(settings): 下拉框回显自定义模型 / Fix model dropdown for custom models

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -16,7 +16,9 @@ export function Settings() {
   const [cliId, setCliId] = useState(existing && existingIsCli ? existing.model : "");
   // API：选中的模型 id + 可编辑的 baseURL / model / key
   const firstApi = apiModels[0];
-  const [apiId, setApiId] = useState(existing && !existingIsCli ? existing.model : firstApi.id);
+  // 回显：如果 localStorage 里的 model 在预设列表中，就匹配对应 id；否则回退到"其它 OpenAI 兼容"
+  const matchedApi = existing && !existingIsCli ? apiModels.find((m) => m.id === existing.model) : null;
+  const [apiId, setApiId] = useState(matchedApi ? matchedApi.id : "custom");
   const [baseURL, setBaseURL] = useState(existing && !existingIsCli ? existing.baseURL : (PROVIDER_BASE[firstApi.provider] || ""));
   const [modelName, setModelName] = useState(existing && !existingIsCli ? existing.model : firstApi.id);
   const [apiKey, setApiKey] = useState(existing && !existingIsCli ? existing.apiKey : "");


### PR DESCRIPTION
## 问题 / Problem

当用户手动填写的 model id（如 Qwen3.6-27B）不在预设列表中时，设置页的「选择模型」下拉框无法正确回显——会 fallback 显示第一项 DeepSeek V4 Flash。

根因：`apiId` 初始化直接用了 `existing.model`，但 `<select>` 的 option value 是预设列表的 id。匹配不到任何 option 时浏览器回退到第一项。

## 修复 / Fix

回显前先查 localStorage 里的 model 是否在预设列表中，不在就选中 `custom`（其它 OpenAI 兼容）。

## Changes
- `frontend/src/pages/Settings.tsx` — 3 lines changed