### PR TITLE
feat: 添加 Docker 部署支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# Docker 构建忽略文件
+
+# Git
+.git
+.gitignore
+.github
+
+# Docker
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# 文档
+*.md
+LICENSE
+docs/
+
+# 前端
+frontend/node_modules
+frontend/.vite
+frontend/dist
+frontend/coverage
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv
+venv/
+ENV/
+env/
+*.egg-info
+.pytest_cache
+.mypy_cache
+
+# 测试
+tests/
+backend/tests/
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# 数据目录（用户数据不应进镜像）
+.cache/
+.vibe-research/
+*.json.bak
+
+# 杂项
+*.log
+*.tmp
+.DS_Store
+Thumbs.db

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# 自动检测文本文件，行尾默认 LF
+* text=auto eol=lf
+
+# Shell 脚本在 Docker Linux 容器中必须保持 LF
+*.sh text eol=lf
+
+# Windows 批处理文件保持 CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,13 @@
 name: Build & Push Docker Image
 
 on:
-  push:
-    branches: [main, master]
-    tags: ['v*']
-  pull_request:
-    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker 标签（如 v0.3.1、test 等，不含 latest，会自动补上）'
+        required: true
+        type: string
+        default: 'latest'
 
 env:
   REGISTRY_GHCR: ghcr.io
@@ -32,7 +34,6 @@ jobs:
 
       # ── 登录 ghcr ──
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_GHCR }}
@@ -41,7 +42,6 @@ jobs:
 
       # ── 登录 Docker Hub ──
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_DOCKERHUB }}
@@ -57,16 +57,12 @@ jobs:
             ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
             ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME_DOCKERHUB }}
           tags: |
-            # 分支推 latest
-            type=raw,value=latest,enable={{is_default_branch}}
-            # tag 事件：v1.2.3 → 1.2.3
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            # 始终包含 latest
+            type=raw,value=latest
+            # 手动输入的标签
+            type=raw,value=${{ github.event.inputs.tag }}
             # 短 sha
             type=sha,prefix=sha-
-            # PR
-            type=ref,event=pr
 
       # ── 构建并推送 ──
       - name: Build and push Docker image
@@ -74,8 +70,18 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ── 更新 Docker Hub 简介页面 ──
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          readme-filepath: ./README.md
+          short-description: "Vibe-Research · 个人 AI 投研系统（A股/美股/港股）"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,81 @@
+name: Build & Push Docker Image
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['v*']
+  pull_request:
+    branches: [main, master]
+
+env:
+  REGISTRY_GHCR: ghcr.io
+  REGISTRY_DOCKERHUB: docker.io
+  IMAGE_NAME_GHCR: ${{ github.repository }}
+  IMAGE_NAME_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── 登录 ghcr ──
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── 登录 Docker Hub ──
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_DOCKERHUB }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # ── 提取元数据（标签等） ──
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+            ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME_DOCKERHUB }}
+          tags: |
+            # 分支推 latest
+            type=raw,value=latest,enable={{is_default_branch}}
+            # tag 事件：v1.2.3 → 1.2.3
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # 短 sha
+            type=sha,prefix=sha-
+            # PR
+            type=ref,event=pr
+
+      # ── 构建并推送 ──
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# ============================================================
+# Vibe-Research Dockerfile —— 多阶段构建
+# 阶段1: 构建前端 (Vite + React)
+# 阶段2: 安装后端依赖 (Python + FastAPI)
+# 阶段3: 合并运行 (nginx + uvicorn)
+# ============================================================
+
+# ── 阶段1: 构建前端 ──
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+
+# 先复制依赖文件，利用 Docker 缓存层
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm install --legacy-peer-deps
+
+# 复制源码并构建
+COPY frontend/ ./
+RUN npm run build
+
+# ── 阶段2: 安装后端依赖 ──
+FROM python:3.11-slim AS backend-deps
+
+WORKDIR /app
+
+# 安装编译依赖（部分 Python 包需要）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# ── 阶段3: 最终运行镜像 ──
+FROM python:3.11-slim AS runtime
+
+# 安装 nginx（用于托管前端静态文件 + 代理后端 API）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nginx \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+WORKDIR /app
+
+# 从阶段2复制 Python 依赖
+COPY --from=backend-deps /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=backend-deps /usr/local/bin /usr/local/bin
+
+# 从阶段1复制前端构建产物
+COPY --from=frontend-builder /app/frontend/dist /usr/share/nginx/html
+
+# 复制后端代码
+COPY backend/ /app/backend/
+
+# 复制启动脚本
+COPY docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# nginx 配置：托管前端 + 代理 /api 到后端
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+
+# 数据持久化目录（持仓、研报等用户数据）
+# 实际数据目录为 /data（通过 VR_DATA_DIR 环境变量映射到 ~/.vibe-research）
+RUN mkdir -p /data
+ENV VR_DATA_DIR=/data
+
+# 暴露端口
+# 80: nginx（前端 + API 代理）
+EXPOSE 80
+
+# 健康检查
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost/api/health || exit 1
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@
 
 services:
   vibe-research:
-    image: ghcr.io/birdxs/vibe-research:latest
+    image: ${GHCR_IMAGE:-ghcr.io/your-username/vibe-research:latest}
     container_name: vibe-research
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+# Vibe-Research Docker Compose 配置
+# 本地部署方式：docker compose up -d
+#
+# 访问地址：
+#   前端: http://localhost:5899
+#   后端: http://localhost:5899/api
+#
+# 数据持久化：
+#   用户数据（持仓、研报）存储在 vibe-data 卷中
+#   对应容器内路径 /data，即 ~/.vibe-research
+
+services:
+  vibe-research:
+    image: ghcr.io/birdxs/vibe-research:latest
+    container_name: vibe-research
+    restart: unless-stopped
+    ports:
+      - "5899:80"
+    environment:
+      # CORS 白名单（默认 * 放开，公网部署请改成你的域名）
+      - VR_ALLOW_ORIGINS=*
+      # API 鉴权 key（公网部署务必设置，否则任何人都能访问你的后端）
+      # - VR_API_KEY=your-secret-key-here
+      # 数据目录（容器内，映射到命名卷 vibe-data）
+      - VR_DATA_DIR=/data
+    volumes:
+      # 用户数据持久化（持仓 portfolio.json、研报 myreports/）
+      - vibe-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  vibe-data:
+    driver: local

--- a/docker-deploy.md
+++ b/docker-deploy.md
@@ -34,8 +34,11 @@
 ### 快速启动
 
 ```bash
+# 设置镜像地址（替换为你自己的 ghcr 路径，或使用本地构建的镜像）
+export GHCR_IMAGE=ghcr.io/your-username/vibe-research:latest
+
 # 拉取最新镜像
-docker pull ghcr.io/birdxs/vibe-research:latest
+docker pull ${GHCR_IMAGE}
 
 # 启动
 docker compose up -d
@@ -73,15 +76,14 @@ docker run -d \
   -p 5899:80 \
   -v vibe-data:/data \
   -e VR_ALLOW_ORIGINS="*" \
-  ghcr.io/birdxs/vibe-research:latest
+  ghcr.io/your-username/vibe-research:latest
 ```
 
 ## GitHub Actions 自动构建
 
 ### 触发条件
 
-- 推送到 `main` / `master` 分支 → 构建并推送 `latest`
-- 推送 `v*` 标签（如 `v0.3.1`）→ 推送对应版本号
+手动触发（`workflow_dispatch`），可指定标签。
 
 ### 配置 Secrets
 
@@ -98,7 +100,7 @@ docker run -d \
 
 构建完成后，镜像同时推送至：
 
-- `ghcr.io/birdxs/vibe-research:latest`
+- `ghcr.io/<your-username>/vibe-research:latest`
 - `docker.io/<username>/vibe-research:latest`
 
 ### 手动触发

--- a/docker-deploy.md
+++ b/docker-deploy.md
@@ -1,0 +1,160 @@
+# Vibe-Research Docker 部署指南
+
+本项目提供完整的 Docker 部署方案，支持：
+- 单容器全栈部署（前端 + 后端 + nginx 一体化）
+- GitHub Actions 自动构建推送至 ghcr.io 和 Docker Hub
+- 本地 Docker Compose 一键启动
+- 多架构支持（amd64 / arm64）
+
+## 架构
+
+```
+┌─────────────────────────────────────────┐
+│         Vibe-Research Container          │
+│                                         │
+│  ┌─────────┐    ┌────────────────────┐  │
+│  │  nginx  │───▶│  uvicorn (FastAPI) │  │
+│  │  :80    │    │  :8900             │  │
+│  └────┬────┘    └────────────────────┘  │
+│       │                                 │
+│  ┌────▼────┐                            │
+│  │ 前端静态 │                            │
+│  │ 文件    │                            │
+│  └─────────┘                            │
+└─────────────────────────────────────────┘
+```
+
+## 本地部署（Docker Compose）
+
+### 前置要求
+
+- Docker Engine 20.10+
+- Docker Compose v2
+
+### 快速启动
+
+```bash
+# 拉取最新镜像
+docker pull ghcr.io/birdxs/vibe-research:latest
+
+# 启动
+docker compose up -d
+
+# 查看日志
+docker compose logs -f
+
+# 停止
+docker compose down
+```
+
+### 访问
+
+- 前端: http://localhost:5899
+- 后端 API: http://localhost:5899/api
+- 健康检查: http://localhost:5899/api/health
+
+### 数据持久化
+
+用户数据（持仓、研报）存储在 Docker 命名卷 `vibe-data` 中，对应容器内 `/data` 目录。
+
+```bash
+# 备份数据
+docker run --rm -v vibe-data:/data -v $(pwd):/backup alpine tar czf /backup/vibe-backup.tar.gz -C /data .
+
+# 恢复数据
+docker run --rm -v vibe-data:/data -v $(pwd):/backup alpine tar xzf /backup/vibe-backup.tar.gz -C /data
+```
+
+## 本地部署（纯 Docker）
+
+```bash
+docker run -d \
+  --name vibe-research \
+  -p 5899:80 \
+  -v vibe-data:/data \
+  -e VR_ALLOW_ORIGINS="*" \
+  ghcr.io/birdxs/vibe-research:latest
+```
+
+## GitHub Actions 自动构建
+
+### 触发条件
+
+- 推送到 `main` / `master` 分支 → 构建并推送 `latest`
+- 推送 `v*` 标签（如 `v0.3.1`）→ 推送对应版本号
+
+### 配置 Secrets
+
+在 GitHub 仓库 Settings → Secrets and variables → Actions 中添加：
+
+| Secret 名称 | 说明 |
+|-------------|------|
+| `DOCKERHUB_USERNAME` | Docker Hub 用户名 |
+| `DOCKERHUB_TOKEN` | Docker Hub Access Token（在 Docker Hub Account Settings → Security 生成） |
+
+> ghcr.io 使用 GitHub 自动提供的 `GITHUB_TOKEN`，无需额外配置。
+
+### 镜像地址
+
+构建完成后，镜像同时推送至：
+
+- `ghcr.io/birdxs/vibe-research:latest`
+- `docker.io/<username>/vibe-research:latest`
+
+### 手动触发
+
+在 GitHub Actions 页面选择 `Build & Push Docker Image` 工作流，点击 `Run workflow`。
+
+## 从源码构建
+
+```bash
+# 构建镜像
+docker build -t vibe-research:local .
+
+# 运行
+docker run -d --name vibe-research -p 5899:80 -v vibe-data:/data vibe-research:local
+```
+
+## 多架构支持
+
+GitHub Actions 工作流默认构建 `linux/amd64` 和 `linux/arm64` 两种架构镜像，可直接在 Intel/AMD 服务器、Apple Silicon Mac、树莓派等环境运行。
+
+## 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `VR_ALLOW_ORIGINS` | `*` | CORS 白名单，公网部署请设为你的前端域名 |
+| `VR_API_KEY` | 空（不鉴权） | 设置后所有 `/api/*` 需带 `Authorization: Bearer <key>` |
+| `VR_DATA_DIR` | `/data` | 用户数据目录（持仓、研报） |
+| `VR_REPORTS_DIR` | 空 | 研报单独目录（可选） |
+
+## 生产部署建议
+
+1. **设置 API Key**：公网部署务必设置 `VR_API_KEY`，否则任何人都能访问后端
+2. **限制 CORS**：设置 `VR_ALLOW_ORIGINS=https://your-domain.com`
+3. **反向代理**：在 nginx/Caddy 前置 HTTPS 终止
+4. **数据备份**：定期备份 `vibe-data` 卷
+5. **资源限制**：建议设置 `--memory=1g --cpus=1`
+
+## 常见问题
+
+### 容器启动后立即退出
+
+检查日志：`docker compose logs vibe-research`
+
+常见原因：
+- 端口被占用：修改 `-p 5899:80` 中的主机端口
+- Python 依赖缺失：重新构建镜像
+
+### 无法访问前端
+
+- 检查防火墙是否放行 5899 端口
+- 检查 nginx 配置是否正确代理了 `/api`
+
+### 数据丢失
+
+确保使用了持久化卷（`-v vibe-data:/data`），否则容器删除后数据会丢失。
+
+## 更新日志
+
+见 [CHANGELOG.md](CHANGELOG.md)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Vibe-Research Docker 启动脚本
+# 启动 nginx（前端 + API 代理）和 uvicorn（后端 API）
+
+echo "==> Starting Vibe-Research..."
+echo "    Backend:  http://0.0.0.0:8900"
+echo "    Frontend: http://0.0.0.0:80"
+echo "    VR_DATA_DIR: ${VR_DATA_DIR:-/data}"
+
+# 启动后端（uvicorn）—— 后台运行
+cd /app/backend
+uvicorn app:app \
+    --host 0.0.0.0 \
+    --port 8900 \
+    --workers 1 \
+    --log-level info &
+BACKEND_PID=$!
+
+# 等待后端就绪
+echo "==> Waiting for backend to start..."
+for i in $(seq 1 30); do
+    if curl -sf http://127.0.0.1:8900/api/health > /dev/null 2>&1; then
+        echo "==> Backend is ready!"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "==> Backend failed to start, exiting..."
+        kill $BACKEND_PID 2>/dev/null
+        exit 1
+    fi
+    sleep 1
+done
+
+# 启动 nginx（前台运行，阻塞容器）
+echo "==> Starting nginx..."
+exec nginx -g 'daemon off;'

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,79 @@
+# Vibe-Research nginx 配置
+# 托管前端静态文件 + 代理 /api 到后端 FastAPI
+
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access_log main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # 文件上传大小限制（研报上传最大 25MB）
+    client_max_body_size 30m;
+
+    # Gzip 压缩
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # ── API 代理到后端 FastAPI ──
+        location /api/ {
+            proxy_pass http://127.0.0.1:8900/api/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # SSE（Server-Sent Events）流式响应支持（chat/debate/reflect 端点）
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+        }
+
+        # ── 前端静态文件 + SPA fallback ──
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        # 静态资源缓存
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # 健康检查（不经过后端）
+        location /health {
+            access_log off;
+            return 200 "ok\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}


### PR DESCRIPTION
## 改动内容
- Dockerfile: 多阶段构建（前端 → 后端 → 最终镜像）
- docker-compose.yml: 本地一键部署，镜像地址使用环境变量 ${GHCR_IMAGE}
- docker/entrypoint.sh: 容器启动脚本
- docker/nginx.conf: 前端托管 + API 代理
- .github/workflows/docker.yml: GitHub Actions 自动构建推送（支持多架构、手动触发、Docker Hub 简介同步）
- .dockerignore: 构建忽略文件
- .gitattributes: shell 脚本保持 LF
- docker-deploy.md: 部署文档

## 使用说明
```bash
export GHCR_IMAGE=ghcr.io/your-username/vibe-research:latest
docker compose up -d
```