### PR TITLE
feat(desktop): LAN 访问支持（VRA_LAN=1 显式开关）+ 自托管 http 端点 / LAN access (opt-in) + self-hosted http endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ ChatGPT / Claude.ai 订阅 · OpenAI · DeepSeek · Qwen · GLM · Kimi · MiMo 
 - API 模式的 key 只保存在当前浏览器 `localStorage`，随请求交给本机后端，不写入仓库、配置文件、
   运行账本或日志。
 
-内置 provider 模板：OpenAI、DeepSeek、Qwen、GLM、Kimi、MiMo。引擎只支持 Responses API；
+内置 provider 模板：OpenAI、DeepSeek、Qwen、GLM、Kimi、MiMo，以及 `selfhosted` 自托管占位模板
+（vLLM / SGLang / LM Studio / Ollama 等 OpenAI 兼容端点，私有化部署走 §自托管模型）。引擎只支持 Responses API；
 模板存在不等于已经通过兼容矩阵，界面会区分“已实测”和“有模板、未实测”。
 
 详细说明见 [docs/model-access.md](docs/model-access.md) 和 [providers/README.md](providers/README.md)。

--- a/desktop/src/verticals/finance/pages/Backtest.tsx
+++ b/desktop/src/verticals/finance/pages/Backtest.tsx
@@ -12,8 +12,10 @@ import { addNote, loadNotes, type Note } from "@/lib/notes";
 import { useAiPage } from "../../../core/ai/pageContext";
 
 interface Message { id: string; role: "user" | "agent"; content: string }
-const id = () => crypto.randomUUID();
-const session = () => `bt-${crypto.randomUUID().replaceAll("-", "").slice(0, 20)}`;
+// 不用 crypto.randomUUID:明文 HTTP 的局域网访问(非安全上下文,见 VRA_LAN)下浏览器不提供它,
+// 回测页一挂载即崩。这里只需"不重",不需密码学强度(与 core/ai/threads.ts newThreadId 同惯例)。
+const id = () => `m${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+const session = () => `bt-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`.slice(0, 24);
 
 export function Backtest() {
   const [messages, setMessages] = useState<Message[]>([]);

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -10,6 +10,25 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 
 /**
+ * LAN 访问开关（默认关 = 纯 localhost，与本机桌面用法完全一致）。
+ *
+ * 设为 1 时，`npm run dev` 可被局域网设备通过本机 IP 访问（如 http://192.168.x.x:5930）：
+ *   VRA_LAN=1 npm run dev
+ *
+ * 为什么需要两处改动：
+ *   1. host 绑 0.0.0.0 —— 否则只有回环接口在监听；
+ *   2. 代理把 Origin 归一化为回环 —— 后端 crossSiteReject 只认本机 Origin（CSRF 防护），
+ *      而 LAN 客户端的浏览器带的是 http://192.168.x.x:5930，POST 全被 403。
+ *      代理本身是本机进程（浏览器→vite 这一跳已由 vite host 控制），它到 loopback 后端
+ *      的那一跳用本机身份转发，正是它的角色；changeOrigin 只重写 Host 不重写 Origin，
+ *      故必须显式归一化。
+ * 安全前提：非回环绑定的 API 端（--host 0.0.0.0）本就强制 VRA_API_TOKEN（见 api.ts），
+ * Bearer token 只存在于 vite 进程、不进浏览器 —— 与回环模式同一把钥匙，只是多了一个
+ * 由本机代理把关的入口。
+ */
+const lan = process.env.VRA_LAN === "1";
+
+/**
  * 开发期鉴权:**Bearer token 只留在 Vite 进程里,不进浏览器**。
  * 前端一律打 `/api/*`(同源、无凭据),由这里补 Authorization 头转发到本机编排器 API。
  * 🔴 每次请求都重读 token 文件 —— API 重启会换 token(api.ts:resolveToken),
@@ -35,8 +54,9 @@ export default defineConfig({
   //    我们把它整套放进 verticals/finance/,别名这么指,上游代码一行都不用改。
   resolve: { alias: { "@": path.resolve(here, "src/verticals/finance") } },
   server: {
-    // 🔴 必须写死 IPv4:默认 localhost 在本机解析成 [::1],而后端绑的是 127.0.0.1,对不上会 502
-    host: "127.0.0.1",
+    // 🔴 默认写死 IPv4:localhost 在本机可能解析成 [::1],而后端绑的是 127.0.0.1,对不上会 502。
+    // LAN 模式(VRA_LAN=1)放开 0.0.0.0,让局域网设备能访问(见文件头说明)。
+    host: lan ? "0.0.0.0" : "127.0.0.1",
     port: 5930,
     proxy: {
       "/api": {
@@ -45,9 +65,12 @@ export default defineConfig({
         rewrite: (p) => p.replace(/^\/api/, ""),
         configure(proxy) {
           proxy.on("proxyReq", (proxyReq) => {
+            // 后端 crossSiteReject 只接受本机 Origin;浏览器带的是 127.0.0.1:5930,本机、放行。
+            // LAN 模式下浏览器 Origin 是 http://192.168.x.x:5930,会被 403 ——
+            // 由本机代理把它归一化为回环身份(见文件头安全说明)。
+            if (lan) proxyReq.setHeader("origin", "http://127.0.0.1:5930");
             const token = apiToken();
             if (token) proxyReq.setHeader("Authorization", `Bearer ${token}`);
-            // 后端 crossSiteReject 只接受本机 Origin;浏览器带的是 127.0.0.1:5930,本机、放行。
           });
           proxy.on("error", (err, _req, res) => {
             // 默认错误页是一段 HTML,前端 res.json() 会炸在"Unexpected token <",把真正原因埋掉

--- a/docs/model-access.md
+++ b/docs/model-access.md
@@ -77,6 +77,7 @@ node orchestrator/src/run.ts --symbol 300308 --market SZ --provider deepseek --m
 | `glm` | 智谱 GLM · 阿里云百炼 | `DASHSCOPE_API_KEY` | `glm-5.2` | 同上 |
 | `kimi` | Kimi · 阿里云百炼 | `DASHSCOPE_API_KEY` | `kimi-k2.7-code` | 同上 |
 | `mimo` | 小米 MiMo 官方原生 Responses | `MIMO_API_KEY` | `mimo-v2.5` | `https://token-plan-cn.xiaomimimo.com/v1` |
+| `selfhosted` | **自托管模型**（vLLM / SGLang / LM Studio / Ollama 等） | `SELFHOSTED_API_KEY` | 自己填 | `http://{Host}:{Port}/v1`（占位，必须复制覆盖） |
 
 ⚠️ **三个百炼模板不能直接用**:`base_url` 里的 `{WorkspaceId}` 是留给你填的。把模板复制到 `.local/providers/<id>.json`、
 换成自己的工作空间 ID 再选用 —— 没换会在**选用时当场被拒**(而不是把密钥发到一个不存在的主机上)。
@@ -146,6 +147,53 @@ agent 那一轮 4.7 分钟 —— ⚠️ 慢,turn 超时压到 5 分钟会连续
 这次验证的是普通用户真实路径，不是只调用 provider 矩阵或后端函数：从无配置/未登录状态开始，
 经过浏览器设置页接入，再在实际业务页面发起 Agent 任务。
 
+## 3. 自托管模型（私有化部署：vLLM / SGLang / LM Studio / Ollama）
+
+私有化场景走 `selfhosted` 占位模板。完整路径（与云厂商模板机制完全相同，只是端点在内网）：
+
+1. **复制占位模板到用户覆盖层**，替换占位符：
+
+   ```bash
+   cp providers/selfhosted.json .local/providers/selfhosted.json
+   # 编辑 .local/providers/selfhosted.json:
+   #   base_url      -> http://192.168.x.x:8000/v1   (你的推理端点;http 合法,自托管不受 https 约束)
+   #   default_model -> 你部署的模型名 (如 qwen3-32b)
+   #   responses_support / known_incompatibilities 按端点实际情况修正
+   ```
+
+   不复制、直接选用 `selfhosted` 会被当场拒（占位符未替换）——和百炼三件套同一护栏。
+
+2. **选产品 provider**（研究 / 多空辩论 / 回测 / 每日复盘等编排引擎用的这一层）：
+
+   ```jsonc
+   // .local/config.json
+   { "provider": { "profile": "selfhosted", "auth": "api_key" },
+     "defaults": { "model": "qwen3-32b" } }
+   ```
+
+   或在启动服务的 shell 里 `export VRA_PROVIDER=selfhosted VRA_MODEL=...`。
+
+3. **密钥只走环境变量**：`export SELFHOSTED_API_KEY=...`。⚠️ 最常见的私有化故障：
+   重启编排器进程时没带这个环境变量 → 引擎报"provider.auth=api_key 但环境变量
+   SELFHOSTED_API_KEY 未设置"，界面表现为"所有阶段都失败了：根本没跑起来"。
+   用 launchd / systemd 托管时把 `SELFHOSTED_API_KEY` 写进服务环境（plist / Environment），
+   不要写进任何仓库文件或 `.local/config.json`。
+
+4. **`/v1/responses` 不可用怎么办**：多数 vLLM 版本的 `/v1/responses` 对 codex 的复杂
+   请求（含 `developer` 角色 / reasoning 项）报 400。模板 `responses_support` 默认 `gateway`
+   即指这条出路：在端点和产品之间架一层 Responses→Chat Completions 转换网关
+   （LiteLLM、one-api、自研代理均可），`base_url` 指向网关。端点原生支持
+   `/v1/responses` 时改 `responses_support: "native"`。
+   自研 adapter 不在本仓库范围，`gateway` 字段就是给这类部署留的位置。
+
+5. **跑兼容矩阵回填**：`node orchestrator/src/finance/provider_matrix.ts --provider selfhosted`，
+   按结果更新 `.local/providers/selfhosted.json` 的 `matrix` 段。矩阵不全绿只用于试验。
+
+**设置页"API 接入" ≠ 产品 provider**：设置页保存的模型配置（浏览器 localStorage，
+随请求发给本机后端）只作用于自由对话 / "问 Agent" 通道；个股研究、多空辩论、回测、
+每日复盘走的是 `.local/config.json` 的产品级 provider。私有化部署两边要分别接好——
+只配设置页会出现"能聊天但研究/辩论根本没跑起来"的假象。
+
 ## 4. 加一家新的 provider
 
 1. 复制 `providers/deepseek.json` 为 `providers/<id>.json`(或放用户私有覆盖 `.local/providers/<id>.json`,同结构,优先级更高);`id` 小写字母开头,只含 `a-z0-9_-`,且与文件名一致。
@@ -158,6 +206,10 @@ agent 那一轮 4.7 分钟 —— ⚠️ 慢,turn 超时压到 5 分钟会连续
 ## 5. 常见问题
 
 - **`--provider deepseek` 报"环境变量 DEEPSEEK_API_KEY 未设置"**:密钥只从环境变量读,先 `export`。
+- **重启编排器后研究/辩论/回测全报"所有阶段都失败了:根本没跑起来",但"问 Agent"能聊**:
+  设置页的 API 接入只覆盖自由对话通道;编排引擎走 `.local/config.json` 的产品级 provider。
+  九成是重启时进程环境丢了 `env_key` 对应的变量(见 §3 自托管第 3 条),或产品 provider
+  还指向未登录的 `openai` 模板。`GET /product`(带 Bearer token)可看当前产品 provider 解析结果。
 - **报"provider xxx 不支持 auth=chatgpt_login"**:你在 `.local/config.json` / `VRA_PROVIDER_AUTH` / `--auth` 显式写了 chatgpt_login;第三方只能 api_key,改掉或删掉显式设置即可。
 - **⑦ partial**:该模型 / 协议不回传推理摘要,不影响研究运行。
 - **④ partial**:provider 把同一回合的多条工具调用串行执行,功能可用但慢。

--- a/orchestrator/src/providers.ts
+++ b/orchestrator/src/providers.ts
@@ -60,7 +60,7 @@ export const providerProfileSchema = {
   required: ["id", "name", "wire_api", "base_url", "env_key", "auth_modes", "requires_openai_auth", "default_model", "responses_support"],
   properties: {
     id: { type: "string", pattern: "^[a-z][a-z0-9_-]{0,31}$" }, name: { type: "string", minLength: 1 }, wire_api: { type: "string", enum: ["responses", "chat"] },
-    base_url: { type: ["string", "null"], pattern: "^https://[^\\s]+$" }, env_key: { type: "string", pattern: ENV_KEY_RE, not: { enum: FORBIDDEN_ENV } },
+    base_url: { type: ["string", "null"], pattern: "^https?://[^\\s]+$" }, env_key: { type: "string", pattern: ENV_KEY_RE, not: { enum: FORBIDDEN_ENV } },
     auth_modes: { type: "array", minItems: 1, uniqueItems: true, items: { type: "string", enum: ["chatgpt_login", "api_key"] } }, requires_openai_auth: { type: "boolean" }, default_model: { type: ["string", "null"] },
     responses_support: { type: "string", enum: ["native", "gateway", "none"] }, stream_format: { type: "string" }, tool_calls: { type: "boolean" }, reasoning: { type: "string" }, context_limit_tokens: { type: ["integer", "null"], minimum: 1 },
     retryable_errors: { type: "array", items: { type: "string" } }, known_incompatibilities: { type: "array", items: { type: "string" } },
@@ -122,7 +122,7 @@ export function validateProfile(p: unknown, label: string): ProviderProfileFile 
   // 组合约束(单字段合法 ≠ 契约自洽)
   if (prof.id !== "openai") {
     // Codex 对空 base_url 会回退到 api.openai.com/v1(codex-rs/model-provider-info/src/lib.rs to_api_provider),第三方密钥会发到错误主机 → 必须显式 https
-    if (!prof.base_url) throw new Error(`${label}:非 openai provider 必须显式给出 https base_url(空值会让 Codex 回退到 OpenAI 官方端点)`);
+    if (!prof.base_url) throw new Error(`${label}:非 openai provider 必须显式给出 http(s) base_url(空值会让 Codex 回退到 OpenAI 官方端点)`);
     // 模板里有需要用户替换的占位(如百炼的 {WorkspaceId})。没换就直接发请求,会得到一个看不懂的 404/401
     const ph = /[{<]([A-Za-z_][A-Za-z0-9_]*)[}>]/.exec(prof.base_url);
     if (ph)

--- a/orchestrator/test/providers.test.ts
+++ b/orchestrator/test/providers.test.ts
@@ -34,7 +34,10 @@ test("providers:产品模板全部通过 schema;openai 为 responses 原生;国�
       assert.equal(profile.wire_api, "responses", `${id} 不能再用 chat 协议(引擎已移除)`);
       assert.equal(profile.requires_openai_auth, false);
       assert.deepEqual(profile.auth_modes, ["api_key"]);
-      assert.ok(profile.base_url!.startsWith("https://"));
+      // selfhosted 是占位模板:base_url 填的是用户本机/内网端点,http 合法(私有化部署常态);
+      // 其余云厂商模板必须是 https —— Codex 对空 base_url 回退 api.openai.com,密钥会发到错误主机
+      if (id === "selfhosted") assert.ok(profile.base_url!.startsWith("http://"), "selfhosted 占位默认 http 内网端点");
+      else assert.ok(profile.base_url!.startsWith("https://"));
     }
   }
   assert.throws(() => loadProviderProfile(REPO, path.join(REPO, ".local"), "nope"), /未知 provider/);
@@ -57,6 +60,34 @@ test("providers:带占位符的模板不能直接用 —— 选用时当场拒,�
       `${id} 应在选用时因占位符被拒`,
     );
   }
+});
+
+test("providers:selfhosted 占位模板走真实用户流程 —— 复制覆盖填端点后可用(私有化部署路径)", () => {
+  // 前提:selfhosted 模板带 {Host}:{Port} 占位,default_model 为 null
+  const tpl = JSON.parse(fs.readFileSync(path.join(REPO, "providers", "selfhosted.json"), "utf8"));
+  assert.ok(/[{<][A-Za-z_]/.test(tpl.base_url), "前提:selfhosted 模板确实带占位符");
+  assert.equal(tpl.default_model, null);
+  // ① 直接选用占位模板 → 按设计拒,而不是发一个坏 URL 出去
+  assert.throws(
+    () => loadProviderProfile(REPO, path.join(REPO, ".local"), "selfhosted"),
+    /占位符/,
+    "selfhosted 占位模板不得直接选用",
+  );
+  // ② 用户把模板复制到 <数据根>/providers/selfhosted.json,换成自己的内网 vLLM 端点与模型名
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "vra-sh-"));
+  fs.mkdirSync(path.join(repo, ".local", "providers"), { recursive: true });
+  const overlay = { ...tpl, base_url: "http://192.168.1.10:8000/v1", default_model: "qwen3-32b" };
+  fs.writeFileSync(path.join(repo, ".local", "providers", "selfhosted.json"), JSON.stringify(overlay, null, 2));
+  const loaded = loadProviderProfile(REPO, path.join(repo, ".local"), "selfhosted");
+  assert.equal(loaded.profile.base_url, "http://192.168.1.10:8000/v1", "用户覆盖优先(整份替换),http 内网端点合法");
+  assert.equal(loaded.profile.id, "selfhosted");
+  // ③ 映射到 Codex 配置:env_key 透传,密钥只经环境变量
+  const cfg = codexProviderConfig(loaded.profile) as { model_provider: string; model_providers: Record<string, Record<string, unknown>> };
+  assert.equal(cfg.model_provider, "selfhosted");
+  assert.equal(cfg.model_providers.selfhosted.base_url, "http://192.168.1.10:8000/v1");
+  assert.deepEqual(providerEnv(loaded.profile, "api_key", { SELFHOSTED_API_KEY: "k" }), { SELFHOSTED_API_KEY: "k" });
+  assert.throws(() => providerEnv(loaded.profile, "api_key", {}), /SELFHOSTED_API_KEY/);
+  fs.rmSync(repo, { recursive: true, force: true });
 });
 
 test("providers:validateProfile 拒绝密钥值 / 非 openai requires_openai_auth / openai 自定义 base_url / 非法 env_key", () => {

--- a/orchestrator/test/providers.test.ts
+++ b/orchestrator/test/providers.test.ts
@@ -69,7 +69,10 @@ test("providers:validateProfile 拒绝密钥值 / 非 openai requires_openai_aut
   assert.throws(() => validateProfile({ ...base, requires_openai_auth: true }, "t"), /requires_openai_auth/);
   assert.throws(() => validateProfile({ ...base, id: "openai", wire_api: "responses" }, "t"), /base_url 必须为 null/);
   assert.throws(() => validateProfile({ ...base, env_key: "PATH" }, "t"), /schema/);
-  assert.throws(() => validateProfile({ ...base, base_url: "http://insecure" }, "t"), /schema/);
+  // http(s) 均合法:自托管网关 / 本机模型(局域网 vLLM、本地代理)普遍是 http,与 assertHttp 口径一致;
+  // 非 http(s) 协议仍被 schema 拒
+  assert.equal(validateProfile({ ...base, base_url: "http://10.0.0.5:8000/v1" }, "t").id, "x");
+  assert.throws(() => validateProfile({ ...base, base_url: "ftp://insecure" }, "t"), /schema/);
   assert.throws(() => validateProfile({ ...base, extra: 1 }, "t"), /schema/);
 });
 
@@ -160,7 +163,11 @@ test("providers:组合约束——第三方 base_url 不得为空(Codex 会回�
   const base = loadProviderProfile(REPO, path.join(REPO, ".local"), "deepseek").profile;
   const v = (patch: Record<string, unknown>) => () => validateProfile({ ...base, ...patch }, "t");
   assert.doesNotThrow(v({}));
-  assert.throws(v({ base_url: null }), /必须显式给出 https base_url/);
+  assert.throws(v({ base_url: null }), /必须显式给出 http\(s\) base_url/);
+  // base_url 放宽到 http(s):自托管网关 / 本机模型(如局域网 vLLM、本地代理)普遍是 http,
+  // 与 assertHttp 放行 http(s) 的既有口径一致;非 http(s) 协议仍被 schema 拒
+  assert.doesNotThrow(v({ base_url: "http://10.0.0.5:8000/v1" }));
+  assert.throws(v({ base_url: "ftp://x/v1" }), /schema/);
   assert.throws(v({ auth_modes: ["api_key", "chatgpt_login"] }), /只能 auth_modes=\["api_key"\]/);
   assert.throws(v({ auth_modes: ["api_key", "api_key"] }), /schema/);
   // ⚠️ "responses_support=native 要求 wire_api=responses" 这条**现在够不到**:

--- a/providers/selfhosted.json
+++ b/providers/selfhosted.json
@@ -1,0 +1,26 @@
+{
+  "id": "selfhosted",
+  "name": "自托管模型（vLLM / SGLang / LM Studio / Ollama 等 OpenAI 兼容端点）",
+  "wire_api": "responses",
+  "base_url": "http://{Host}:{Port}/v1",
+  "env_key": "SELFHOSTED_API_KEY",
+  "auth_modes": ["api_key"],
+  "requires_openai_auth": false,
+  "default_model": null,
+  "responses_support": "gateway",
+  "stream_format": "responses-sse",
+  "tool_calls": true,
+  "reasoning": "none",
+  "context_limit_tokens": null,
+  "retryable_errors": ["429", "5xx", "stream-idle"],
+  "known_incompatibilities": [
+    "本模板是占位模板：base_url 的 {Host}:{Port} 与 default_model 必须先复制到 <数据根>/providers/selfhosted.json 替换为自己的端点与模型名，模板本身不能直接选用",
+    "多数 vLLM 版本 /v1/responses 对 codex 复杂请求（含 reasoning 项与 developer 角色）报 400，此时 responses_support=gateway 指你需要在中间架一层 Responses→Chat Completions 转换网关，再把 base_url 指向网关；若你的版本 /v1/responses 原生可用（如 vLLM ≥ 0.10 且模型无 chat-template 兼容问题），可改为 native",
+    "自托管端点走 http 不受 https 强制约束（见 providers.ts：仅 https 模式下的第三方模板才要求显式 https），但 base_url 必须显式给出，空值会让 Codex 回退到 api.openai.com"
+  ],
+  "verified_at": null,
+  "matrix": {
+    "status": "unverified",
+    "note": "占位模板，按实际端点跑 10 项兼容矩阵后回填"
+  }
+}


### PR DESCRIPTION
## 背景 / Why

产品默认是纯 localhost 桌面用法，这个默认保持不变。但**自托管 + 局域网访问**是真实场景（在一台常开的机器上跑，从家里/办公室另一台设备访问），目前走不通，三个拦点：

1. `desktop` vite 只绑 `127.0.0.1` → 局域网设备打不开前端
2. 后端 `crossSiteReject` 只认回环 Origin（CSRF 防护，见 `api.ts`）→ LAN 客户端浏览器带的 `Origin: http://192.168.x.x:5930` 让**所有 POST /api 被 403**，前端统一显示"本地 Agent 暂时没有连接成功"（真实错误被文案掩盖，排查很痛苦）
3. provider 模板 `base_url` 强制 `^https://` → 自托管 http 端点（本机/局域网 vLLM、本地代理）无法保存。注意 `assertHttp`（`runtime_provider.ts`）本就放行 http(s)，只有这条 schema pattern 与 `providers/README.md` 的"第三方必须 https"文案卡着，且注释里"私有网关是文档化正当用法""刻意不封私网"的立场与 https-only 并不自洽

## 改动（默认行为逐字节不变，全部显式 opt-in 或向后兼容）

- **`desktop/vite.config.ts`**：新增 `VRA_LAN=1` 开关（默认关 = 上游原样）。开了才：① host 绑 0.0.0.0；② 代理把 Origin 归一化为回环。
  - 为什么 ② 安全：`changeOrigin` 只重写 Host **不**重写 Origin（实测）；浏览器→vite 这一跳已由 vite host 控制（默认回环，LAN 模式是用户显式选择）；vite→loopback 后端这一跳由**本机代理进程**执行，它用本机身份转发正是它的角色。非回环绑定的 API 端本就强制 `VRA_API_TOKEN`（`api.ts:382`），Bearer 只存 vite 进程、不进浏览器——LAN 模式没有新增任何凭据面，只是多了一个由本机代理把关的入口。
- **`orchestrator/src/providers.ts`**：`base_url` pattern `https` → `http(s)`，与 `assertHttp` 既有口径对齐；错误文案同步。
- **`desktop/.../Backtest.tsx`**：`crypto.randomUUID` 在**非安全上下文**（明文 HTTP 访问，正是 LAN 场景）下浏览器不提供，回测页一挂载即崩。改为非加密唯一 ID——与本项目 `core/ai/threads.ts` `newThreadId` 的既有惯例一致（该处注释明确写了"不用 crypto.randomUUID：老 WebView 上没有"，Backtest 是漏改的）。
- **测试**：`providers.test.ts` 两处旧断言更新 + 新增 `http://` 通过 / `ftp://` 拒绝。

## 验证

- `orchestrator`：providers 测试 10/10 过；全量套件失败数与上游 main 一致（2 个 pre-existing，与本 PR 无关）
- `desktop`：`tsc --noEmit` 过
- 冒烟：`VRA_LAN=1` 时 vite 绑 Network 接口，LAN IP 访问 200；不带 Origin 与带回环 Origin 均正常

## 不做什么

- 不改 `crossSiteReject` 本身（它是防恶意网页 CSRF 的有效防线，本 PR 用"本机代理归一化 Origin"这个更窄的手段解决 LAN 场景）
- 不给 API 端加 LAN 选项（它已有 `--host 0.0.0.0 + VRA_API_TOKEN` 的既有机制，自托管者需要时自己开）