### PR TITLE
feat(providers): add OrcaRouter as a built-in provider template

### DIFF
--- a/providers/orcarouter.json
+++ b/providers/orcarouter.json
@@ -1,0 +1,31 @@
+{
+  "id": "orcarouter",
+  "name": "OrcaRouter(OpenAI 兼容网关 · 自适应路由 / 自动故障转移 / agent 治理)",
+  "wire_api": "responses",
+  "base_url": "https://api.orcarouter.ai/v1",
+  "env_key": "ORCAROUTER_API_KEY",
+  "auth_modes": [
+    "api_key"
+  ],
+  "requires_openai_auth": false,
+  "default_model": "orcarouter/auto",
+  "responses_support": "native",
+  "stream_format": "responses-sse",
+  "tool_calls": true,
+  "reasoning": "orcarouter/auto 实测回传 reasoning 项(由路由到的模型决定);reasoning.summary 接受",
+  "context_limit_tokens": null,
+  "retryable_errors": [
+    "429",
+    "5xx",
+    "stream-idle"
+  ],
+  "known_incompatibilities": [
+    "orcarouter/auto 下实际模型由路由器按请求挑选(实测路由到 deepseek-v4-pro),行为(reasoning / 多轮 / 上下文长度)随路由到的厂商变化",
+    "多轮 previous_response_id 是否被遵守取决于路由到的模型;store 恒为 true"
+  ],
+  "matrix": {
+    "status": "untested",
+    "note": "2026-08-31 live 探针:POST /v1/responses → 200 原生 Responses 对象;responses-sse 流式;text.format.type=json_schema 接受。完整 10 项用 provider_matrix.ts 跑后回填"
+  },
+  "verified_at": "2026-08-31"
+}


### PR DESCRIPTION
## What this PR does

Adds **OrcaRouter** as a built-in provider template in `providers/orcarouter.json`, so it shows up alongside OpenAI, DeepSeek, Qwen, GLM, Kimi, and MiMo on the **Connect AI → API access** page and in `--provider orcarouter` CLI runs.

## Why it fits this project

Vibe Research describes itself as *"a local financial research workbench built on the Codex Harness"*, and its model-access model is a single rule: **the engine supports the Responses API only** — any third-party vendor must either expose an OpenAI-compatible `/responses` endpoint or sit behind a gateway. OrcaRouter does the first: `https://api.orcarouter.ai/v1` is a native OpenAI-compatible Responses endpoint, so the template declares `wire_api: "responses"` / `responses_support: "native"` and needs no gateway — the same shape as the existing DeepSeek template.

The key for the integration is that OrcaRouter is itself an AI gateway. Just like Vibe Research already lets users pick a provider and let Codex choose the model, OrcaRouter exposes a provider/model namespace (`vendor/model`, plus `orcarouter/auto` for router-picked routing) across 200+ models behind the same endpoint. Adding it as a first-class named provider means users of this workbench get adaptive routing, automatic failover, and zero-markup inference for their research runs — without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What was verified (2026-08-31)

- `POST https://api.orcarouter.ai/v1/responses` returns a **200** native Responses object (router picked `deepseek-v4-pro`).
- Streaming is Responses-SSE (`event: response.created` / `response.output_item.added` / `response.reasoning_text.delta` …), matching the engine's expected stream format.
- Function calling works: the endpoint returns a completed `function_call` item with a proper `call_id` and `arguments`.
- `text.format.type=json_schema` is accepted, so the template keeps the default `structured_output: json_schema` path (no prompt-fallback needed).
- The template passes `validateProfile`, loads through `loadProviderProfile`, and the full orchestrator provider test suite (`providers.test.ts`, `runtime_provider.test.ts`) is green with it in place. `tsc --noEmit` is clean.

> Note: `matrix.status` is `untested` — I ran `provider_matrix.ts` in this container and the protocol-level items passed (①, ⑥, ⑦, ⑨, ⑩), but the tool-execution items fail in this sandbox because the Codex harness cannot actually run shell commands here (no PATH aliases / sandbox setup), so I did not mark the 10-item matrix green. The direct endpoint probes above cover the protocol surface the matrix checks. A maintainer with a working local Codex setup can complete the matrix with:
> `node orchestrator/src/finance/provider_matrix.ts --provider orcarouter --model orcarouter/auto`

## Contact

[OrcaRouter](https://www.orcarouter.ai) · Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
