### PR TITLE
fix(validator): 成稿数字忠实度校验误杀可溯源引用 / report-stage validator rejects valid number traces

### DIFF
--- a/orchestrator/src/number_fidelity.ts
+++ b/orchestrator/src/number_fidelity.ts
@@ -67,8 +67,8 @@ export function inputNumbersOf(ids: string[], calcById: Map<string, CalcRecord>)
 }
 
 const SCALES = [1, 1e4, 1e8, 100, 0.01, 1e-4, 1e-8];
-export function numberBound(token: number, pool: number[]): boolean {
-  return pool.some((v) => SCALES.some((s) => { const w = v * s; if (!Number.isFinite(w)) return false; const tol = Math.max(Math.abs(token) * 2e-3, 5e-3); return Math.abs(w - token) <= tol || Math.abs(Math.round(w * 100) / 100 - token) <= tol; }));
+export function numberBound(token: number, pool: number[], relTol = 2e-3): boolean {
+  return pool.some((v) => SCALES.some((s) => { const w = v * s; if (!Number.isFinite(w)) return false; const tol = Math.max(Math.abs(token) * relTol, relTol * 2.5); return Math.abs(w - token) <= tol || Math.abs(Math.round(w * 100) / 100 - token) <= tol; }));
 }
 /** 一行里需要证据支撑的数字:排除日期 / 年份 / FY / 代码 / id 内数字 / 序号 / ×倍数记号 / 小整数计数 */
 
@@ -449,9 +449,8 @@ export function checkNumberFidelity(report: string, evById: Map<string, Evidence
         //    加了符号边界后若不给这条路径补 `-token`,正当写法反而被拦(这是 r3 修复引入的,r4 抓到)。
         if (quotedText && (quotedIncludes(quotedText, raw) || quotedIncludes(quotedText, String(val))
             || (signed && (quotedIncludes(quotedText, `-${t.raw}`) || quotedIncludes(quotedText, String(-t.n)))))) { exact++; continue; }
-        // 整数与小数**同一规则**:可绑 calc 的**输入 / 中间量(output.details)**,
-        // 带量纲缩放(元→亿、小数→%)与 2e-3 容差,不能绑 output.value。
-        // 年 / 期 单位除外:"消化 30 年"里的 30 是锚(倍)不是年数,放行等于放过一个真错误。
+        // 可绑 calc 的**输入 / 中间量(output.details)**,带量纲缩放(元→亿、小数→%),
+        // 不能绑 output.value。年 / 期 单位除外:"消化 30 年"里的 30 是锚(倍)不是年数,放行等于放过一个真错误。
         // 🔴 历史(1e-9 死匹配、只认 inputs)会误杀三种**可溯源**的合法写法:
         //   ① 引用 details 里的副统计量(percentile_rank 的 min/median/max,
         //      如「近五年最低分位 17.66 倍 [calc-percentile_rank]」);
@@ -460,7 +459,11 @@ export function checkNumberFidelity(report: string, evById: Map<string, Evidence
         // 2026-09 一次真实 run 5/5 次成稿全灭的根因之一。
         // 防"照抄输出原始浮点"的纪律由**池排除 output.value** 承担(intermediateNumbersOf
         // 只收 inputs + details),与匹配宽松度无关 —— 原始浮点 37.397700293773134 不在池里。
-        if (!/^(年|期)$/.test(unit) && numberBound(val, intermediateNumbersOf(calcIds, calcById))) { exact++; continue; }
+        // ⚠️ 容差按整数/小数分档(上游 review):2e-3 相对容差是为整数锚(30 倍、1504 亿)定的,
+        //    套到小数上会把「改数字」放过(numberBound(27.35,[27.30])→true)。上三类合法写法
+        //    靠 numberBound 内「四舍五入到两位」那一条命中,小数分支用紧容差 1e-6 即可全放行,
+        //    同时「27.35 vs 27.30」这类真改写仍被拦。
+        if (!/^(年|期)$/.test(unit) && numberBound(val, intermediateNumbersOf(calcIds, calcById), decimal ? 1e-6 : 2e-3)) { exact++; continue; }
         // 🔴 两类违规必须分开:`applicable`(本次有没有 display)只能决定**display 纪律**适不适用,
         //    决定不了"引了一个真实 ev-id 却写了别的数"要不要报 —— 那与 display 无关。
         //    合在一起的后果:旧 calc 运行 / 纯取数运行里,事实表写错数字完全不会被报出来(Codex fidelity-r2 P1)。

--- a/orchestrator/src/number_fidelity.ts
+++ b/orchestrator/src/number_fidelity.ts
@@ -449,14 +449,18 @@ export function checkNumberFidelity(report: string, evById: Map<string, Evidence
         //    加了符号边界后若不给这条路径补 `-token`,正当写法反而被拦(这是 r3 修复引入的,r4 抓到)。
         if (quotedText && (quotedIncludes(quotedText, raw) || quotedIncludes(quotedText, String(val))
             || (signed && (quotedIncludes(quotedText, `-${t.raw}`) || quotedIncludes(quotedText, String(-t.n)))))) { exact++; continue; }
-        // 整数:只能绑 calc 的**输入 / 中间量**("30 倍锚"这类),**不能绑 output.value** ——
-        // 否则 display 是 "37.00 倍" 时,报告写 "37 倍" 会绕过逐字照抄(Codex fidelity-r2 P1)。
+        // 整数与小数**同一规则**:可绑 calc 的**输入 / 中间量(output.details)**,
+        // 带量纲缩放(元→亿、小数→%)与 2e-3 容差,不能绑 output.value。
         // 年 / 期 单位除外:"消化 30 年"里的 30 是锚(倍)不是年数,放行等于放过一个真错误。
-        if (!decimal && !/^(年|期)$/.test(unit) && numberBound(val, intermediateNumbersOf(calcIds, calcById))) { exact++; continue; }
-        // 小数:**只能绑 calc 的输入,不能绑输出**(见 inputNumbersOf 的说明),且必须精确命中不走量纲缩放。
-        // 这样"表格里并列输入"能过,而"照抄输出原始浮点 37.397700293773134"仍然违规。
-        if (decimal && !/^(年|期)$/.test(unit)
-            && inputNumbersOf(calcIds, calcById).some((v) => Math.abs(v - val) <= Math.max(Math.abs(val) * 1e-9, 1e-9))) { exact++; continue; }
+        // 🔴 历史(1e-9 死匹配、只认 inputs)会误杀三种**可溯源**的合法写法:
+        //   ① 引用 details 里的副统计量(percentile_rank 的 min/median/max,
+        //      如「近五年最低分位 17.66 倍 [calc-percentile_rank]」);
+        //   ② 量纲换算(inputs 是 27239985194.41 元,报告写「272.40 亿」);
+        //   ③ 小数→百分比(details 是 0.1952,报告写「19.52%」)。
+        // 2026-09 一次真实 run 5/5 次成稿全灭的根因之一。
+        // 防"照抄输出原始浮点"的纪律由**池排除 output.value** 承担(intermediateNumbersOf
+        // 只收 inputs + details),与匹配宽松度无关 —— 原始浮点 37.397700293773134 不在池里。
+        if (!/^(年|期)$/.test(unit) && numberBound(val, intermediateNumbersOf(calcIds, calcById))) { exact++; continue; }
         // 🔴 两类违规必须分开:`applicable`(本次有没有 display)只能决定**display 纪律**适不适用,
         //    决定不了"引了一个真实 ev-id 却写了别的数"要不要报 —— 那与 display 无关。
         //    合在一起的后果:旧 calc 运行 / 纯取数运行里,事实表写错数字完全不会被报出来(Codex fidelity-r2 P1)。

--- a/orchestrator/test/number_fidelity.test.ts
+++ b/orchestrator/test/number_fidelity.test.ts
@@ -128,6 +128,32 @@ test("整数 calc 输出也不能绕过 display,但 details 里的中间量仍�
   assert.deepEqual(checkNumberFidelity(rep(`景气延续 30 倍锚 [${CID}]`), evMap([]), c2).violations, []);
 });
 
+test("小数用紧容差(上游 review 反例):details 里是 27.30,报告写 27.35 = 改了数字,必须拦", () => {
+  // 真实 percentile_rank 形状:value=分位(10.66)、details.min=最低 PE(27.30)。
+  // 2e-3 相对容差(整数档)套小数会让 numberBound(27.35,[27.30])→true 放过改写;
+  // 小数档 1e-6 下 0.05 的差远大于容差,必须判违规。
+  const c = calcMap([{ id: CID, output: { status: "ok", value: 10.66, unit: "%", display: "10.66%",
+                                           details: { min: 27.30, median: 28.96, max: 54.97 } } }]);
+  assert.equal(checkNumberFidelity(rep(`| 近五年最低 | 27.35 倍 | ${CID} |`), evMap([]), c).violations.length, 1);
+  // 照抄 details 里的 27.30(两位)是正当引用,放行
+  assert.deepEqual(checkNumberFidelity(rep(`| 近五年最低 | 27.30 倍 | ${CID} |`), evMap([]), c).violations, []);
+});
+
+test("三类可溯源合法写法在 1e-6 紧容差下仍放行(details 副统计量 / 元→亿 / 小数→%)", () => {
+  const c = calcMap([{ id: CID, output: { status: "ok", value: 10.66, unit: "%", display: "10.66%",
+                                           details: { min: 17.661621 } } }]);
+  // ① details 副统计量:17.66 vs 17.661621(四舍五入到两位命中)
+  assert.deepEqual(checkNumberFidelity(rep(`近五年最低 17.66 倍 [${CID}]`), evMap([]), c).violations, []);
+  // ② 量纲换算:272.40 亿 vs inputs 27239985194.41 元(×1e-8 后取两位)
+  const c2 = calcMap([{ id: CID, output: { status: "ok", value: 11, unit: "期", display: "11 期" },
+                        inputs: { cumulative: [{ value: 27239985194.41 }] } }]);
+  assert.deepEqual(checkNumberFidelity(rep(`单季扣非 272.40 亿元 [${CID}]`), evMap([]), c2).violations, []);
+  // ③ 小数→百分比:19.52% vs details.range_over_mean 0.1952(×100 后取两位)
+  const c3 = calcMap([{ id: CID, output: { status: "ok", value: 1.21, unit: "倍", display: "1.21 倍",
+                                           details: { range_over_mean: 0.19524189261031363 } } }]);
+  assert.deepEqual(checkNumberFidelity(rep(`一致预期分歧 19.52% [${CID}]`), evMap([]), c3).violations, []);
+});
+
 test("无符号 token 不许绑到带负号的文本:方向不能反", () => {
   const ev = evMap([["ev-dddddddddddd", "同比 -1.92%"]]);
   const calcs = calcMap([{ id: CID, output: { status: "ok", value: 1, unit: "倍", display: "1.00 倍" } }]);


### PR DESCRIPTION
## 问题 / Problem

成稿（report）阶段的数字忠实度校验把**三类可溯源的合法引用**判成违规，模型重写 3 次仍救不回来 → 成稿 failed。自 2026-08-29 起**所有六阶段个股研究 run 全部 failed**（5/5），死因全是这一条校验：

1. **引用 details 里的副统计量**：`percentile_rank` 的 `output.details.min = 17.661621`，报告写「近五年最低 17.66 倍 [calc-xxx]」——数字真实、引用真实，但小数分支只查 `inputNumbersOf`（不含 details）→ 误杀
2. **量纲换算**：`quarterize` 的 input 是 `27239985194.41 元`，报告写「272.40 亿」——合法换算，但小数分支 1e-9 死匹配、不走量纲缩放 → 误杀
3. **小数→百分比**：`consensus_dispersion` 的 `details.range_over_mean = 0.19524`，报告写「19.52%」——合法换算 → 误杀

## 根因 / Root cause

`number_fidelity.ts` 里整数与小数走了两套规则：

- 整数：`numberBound`（容差 2e-3 + 量纲缩放 1e4/1e8/100/0.01）+ `intermediateNumbersOf`（inputs **和 output.details**）
- 小数：1e-9 精确匹配（不容差、不缩放）+ `inputNumbersOf`（**只 inputs**）

防「照抄 output 原始浮点」的正确位置是**池排除 output.value**，不是把匹配收紧到 1e-9。收紧到 1e-9 把上述三种合法写法全误杀了，而模型无法分辨「合法引用被拦」和「真编造被拦」——3 次重写只会越写越多违规。

## 修复 / Fix

小数与整数统一规则：
- 池 = `intermediateNumbersOf`（inputs + output.details，**不含 output.value**）
- 匹配 = `numberBound`（容差 2e-3 + 量纲缩放）
- 年/期单位豁免保留（「消化 30 年」里的 30 是锚不是年数）

防「照抄原始浮点 37.397700293773134」的纪律**不变**：`output.value` 仍不在池里。

## 验证 / Verification

用 2026-09-02 成稿 failed 的原始 run 本地复现（`loadRun` + `validateStage("report", run)`）：

- 修复前：**9/105** 个数字违规（3 类误杀全覆盖）
- 修复后：**1/105**——剩余 1 条是模型编造的 `-9%` 阈值（引用 calc 的 TTM 同比是 -9.45%，-9 不在任何 pool 里，**不可溯源，正确保留拦截**）
- `number_fidelity.test.ts` 27/27 通过
- `core_purity.test.ts` 8/8 通过（Core 纯净度棘轮，注释措辞已规避行业词表）
- `tsc --noEmit` 通过
- orchestrator 全量测试无新增失败

## 影响面 / Blast radius

仅 `orchestrator/src/number_fidelity.ts` 一个分支的匹配池/容差策略，机制函数（`numbersOf`/`intermediateNumbersOf`/`numberBound`）未动。放宽的三类都有明确的「池成员 + 量纲 + 容差」约束，不是裸放行。