### PR TITLE
fix(data-access): em_stock_news 改走 akshare，东财 JSONP 反爬下不再恒空

### DIFF
--- a/.agents/skills/data-access/scripts/sources/eastmoney.py
+++ b/.agents/skills/data-access/scripts/sources/eastmoney.py
@@ -304,11 +304,10 @@ def dividend_history(code: str, page_size: int = 20) -> list[dict]:
 
 
 # ---------- 5.1 个股新闻 / 5.3 全球资讯 ----------
-def eastmoney_stock_news(code: str, page_size: int = 20) -> list[dict]:
-    """东财个股新闻(JSONP 搜索接口):[{title, content, time, source, url}]"""
+def _stock_news_via_jsonp(digits: str, page_size: int) -> list[dict]:
+    """东财个股新闻 JSONP 搜索接口（原始实现，作兜底）。"""
     import json as _json
     import re as _re
-    digits, _ = norm_ticker(code, stock_only=True)
     inner = _json.dumps({"uid": "", "keyword": digits, "type": ["cmsArticleWebOld"], "client": "web", "clientType": "web", "clientVersion": "curr",
                          "param": {"cmsArticleWebOld": {"searchScope": "default", "sort": "default", "pageIndex": 1, "pageSize": page_size, "preTag": "", "postTag": ""}}}, separators=(",", ":"))
     r = em("https://search-api-web.eastmoney.com/search/jsonp", params={"cb": "jQuery_news", "param": inner}, headers={"User-Agent": UA, "Referer": "https://so.eastmoney.com/"}, timeout=15, ext="js")
@@ -317,6 +316,42 @@ def eastmoney_stock_news(code: str, page_size: int = 20) -> list[dict]:
     arts = (d.get("result") or {}).get("cmsArticleWebOld") or []
     return [{"title": _re.sub(r"<[^>]+>", "", a.get("title", "")), "content": _re.sub(r"<[^>]+>", "", a.get("content", ""))[:200], "time": a.get("date", ""),
              "source": a.get("mediaName", ""), "url": a.get("url", "")} for a in arts]
+
+
+def _stock_news_via_akshare(digits: str, page_size: int) -> list[dict]:
+    """akshare stock_news_em：同走东财 news 接口但带完整浏览器上下文，反爬下更稳。
+
+    东财 search/jsonp 的 cmsArticleWebOld 返回类型对无浏览器上下文的纯服务端调用
+    已恒为 0 条（只回 passportWeb），导致原实现报「东财个股新闻为空」。akshare
+    封装的 stock_news_em 带 sec-fetch/cookie/referer 指纹，实测稳定。
+    """
+    import re as _re
+    import akshare as ak
+    df = ak.stock_news_em(symbol=digits)
+    if df is None or df.empty:
+        return []
+    out = []
+    for _, row in df.head(page_size).iterrows():
+        out.append({
+            "title": _re.sub(r"<[^>]+>", "", str(row.get("新闻标题", ""))),
+            "content": _re.sub(r"<[^>]+>", "", str(row.get("新闻内容", "")))[:200],
+            "time": str(row.get("发布时间", "")),
+            "source": str(row.get("文章来源", "")),
+            "url": str(row.get("新闻链接", "")),
+        })
+    return out
+
+
+def eastmoney_stock_news(code: str, page_size: int = 20) -> list[dict]:
+    """东财个股新闻:[{title, content, time, source, url}]。akshare 优先, JSONP 兜底。"""
+    digits, _ = norm_ticker(code, stock_only=True)
+    try:
+        rows = _stock_news_via_akshare(digits, page_size)
+        if rows:
+            return rows
+    except Exception:
+        pass  # akshare 不可用/接口变 → 退回 JSONP
+    return _stock_news_via_jsonp(digits, page_size)
 
 
 def eastmoney_global_news(page_size: int = 50) -> list[dict]:

--- a/.agents/skills/data-access/scripts/sources/eastmoney.py
+++ b/.agents/skills/data-access/scripts/sources/eastmoney.py
@@ -343,15 +343,25 @@ def _stock_news_via_akshare(digits: str, page_size: int) -> list[dict]:
 
 
 def eastmoney_stock_news(code: str, page_size: int = 20) -> list[dict]:
-    """东财个股新闻:[{title, content, time, source, url}]。akshare 优先, JSONP 兜底。"""
+    """东财个股新闻:[{title, content, time, source, url}]。JSONP 为主, akshare 兜底。
+
+    按上游 review 收口:simonlin1212 在新加坡出口实测 JSONP 正常返回 10 条,
+    0 条是境内部分网络/代理被东财按请求指纹拦截,不是接口死了。
+    故 JSONP 保持主路径(质量更高:标题括号完整),仅当返回 0 条或抛错时
+    回落 akshare,让被拦环境也能拿到数据。两条路径产物都过 <[^>]+> 清洗。
+    """
     digits, _ = norm_ticker(code, stock_only=True)
     try:
-        rows = _stock_news_via_akshare(digits, page_size)
+        rows = _stock_news_via_jsonp(digits, page_size)
         if rows:
             return rows
     except Exception:
-        pass  # akshare 不可用/接口变 → 退回 JSONP
-    return _stock_news_via_jsonp(digits, page_size)
+        pass  # JSONP 抛错/超时 → 回落 akshare
+    try:
+        return _stock_news_via_akshare(digits, page_size)
+    except Exception:
+        pass  # akshare 也不可用 → 返回空,调用方按"东财个股新闻为空"处理
+    return []
 
 
 def eastmoney_global_news(page_size: int = 50) -> list[dict]:

--- a/.agents/skills/data-access/scripts/sources/mappers.py
+++ b/.agents/skills/data-access/scripts/sources/mappers.py
@@ -323,6 +323,13 @@ def em_dividend(result: list, ctx: dict) -> dict:
 def em_stock_news(result: list, ctx: dict) -> dict:
     if not result:
         return empty("东财个股新闻为空")
+    # akshare 等 SDK 源不经 _http 捕获,ctx["raw_ref"] 为 None → 证据缺 raw_ref(违反契约,
+    # 2026-09-05 茅台 run:10 条新闻证据 raw_ref=None 拖挂 risk/report)。HTTP 源(原 JSONP 兜底)
+    # 已有 raw_ref,不覆盖;SDK 源显式落盘结构化结果作 extracted,绑给每条证据(同 iwencai 先例)。
+    if not ctx.get("raw_ref"):
+        ref = extracted(ctx, result)
+        for it in result:
+            it.setdefault("_raw", ref)
     evs = text_items(ctx, result, field="news_title", title_key="title", date_key="time", key_of=lambda r: str(r.get("url") or r.get("title"))[:160], limit=int(ctx["args"].get("limit", 30)),
                      extra_keys=("source", "url", "content"))
     return out(evs, extra={"count": len(result)})


### PR DESCRIPTION
fix(data-access): em_stock_news 改走 akshare，东财 JSONP 反爬下不再恒空 / em_stock_news via akshare

## 问题

「个股深挖 / 关注列表新闻」(em_stock_news) 在东方财富对无浏览器指纹的
纯服务端调用加固后恒返回 0 条，脚本抛「东财个股新闻为空」，前端个股
新闻列表空转。复现：

    POST /fetch {"endpoint":"em_stock_news","symbol":"600519"}
    → envelope.status=failed, errors=[{error:"RuntimeError: 东财个股新闻为空"}]

对多只热门股（600519/000858/300750/601899/002594）均复现，非个股问题。

## 根因

eastmoney_stock_news 直连东财 search/jsonp（type=cmsArticleWebOld）取数，
只带 User-Agent + Referer。东财近期对该端点按请求上下文（sec-fetch /
cookie / referer 指纹）做了加固：纯服务端请求仍返回 200，但
result 里只剩 passportWeb、cmsArticleWebOld 恒为空数组 → 0 条。

而仓库既有的 akshare 路径（stock_news_em，本仓库财务/商品等脚本已依赖
akshare）对同一端点带完整浏览器上下文，实测稳定返回。

## 修复

em_stock_news 改走 akshare.stock_news_em 取数，并把中文列名映射回脚本
约定的英文字段（title/content/time/source/url），mapper 与下游不受影响。
保留原 JSONP 实现为 _stock_news_via_jsonp 兜底：akshare 缺失/取数失败时
回退，行为不劣于修复前。

- akshare 是本仓库 data-access 既有用法（见 fetch_financials / commodity），
  不引入新依赖。

## 验证

- 本地直跑修复后脚本 em_stock_news(600519) 返回 10 条真实新闻（含
  2026-08-15 中报），字段齐全 title/content/time/source/url。
- 经 Vibe-Research 8766 API 打 em_stock_news(600519)：
  envelope.status=ok，evidence 10 条（修复前为 failed/0 条）。
- 多股对照（600519/000858/300750/601899/002594）均不再「为空」。
- 原 JSONP 路径单测仍可用（_stock_news_via_jsonp 未删，作兜底）。