### PR TITLE
fix(validator): calcs/ 参数文件致 validateStage TypeError 判死整个 run

### DIFF
--- a/orchestrator/src/merge.ts
+++ b/orchestrator/src/merge.ts
@@ -69,7 +69,15 @@ export function loadFetch(runDir: string): Record<string, FetchEnvelope> {
 }
 
 export function loadCalcs(runDir: string): { file: string; record: CalcRecord | null }[] {
-  return listFiles(path.join(runDir, "calcs"), ".json").map((f) => ({ file: f, record: readJsonIfExists<CalcRecord>(f) }));
+  return listFiles(path.join(runDir, "calcs"), ".json")
+    .filter((f) => {
+      // agent 会往 calcs/ 里写临时参数文件(args_*/sq_* 之类,绕过 shell 长参数),
+      // 它们没有 calculation_id —— 不是计算记录,收进 run.calcs 会让下游
+      // validateStage 读 record.output 时崩(2026-09-05 茅台 run:TypeError 判死整个 run)。
+      const r = readJsonIfExists<CalcRecord>(f);
+      return r != null && typeof (r as unknown as { calculation_id?: unknown }).calculation_id === "string";
+    })
+    .map((f) => ({ file: f, record: readJsonIfExists<CalcRecord>(f) }));
 }
 
 /** 合并证据:按 id 去重;同 id 不同 value 记 id 冲突(完整性错误) */

--- a/orchestrator/src/validator.ts
+++ b/orchestrator/src/validator.ts
@@ -325,6 +325,10 @@ export function validateStage(stage: Stage, run: RunView): ValidationResult {
       if (r.ref_type === "evidence" && !run.evidenceIds.has(r.ref_id)) errors.push(`${path.basename(c.file)} 引用了不存在的 evidence ${r.ref_id}`);
       if (r.ref_type === "calculation" && !run.calcIds.has(r.ref_id)) errors.push(`${path.basename(c.file)} 引用了不存在的 calculation ${r.ref_id}`);
     }
+    // output 可能缺失(半成品 / 非标准记录):缺失不是"无 inputs_refs",不该判错,
+    // 更不能让整个 validateStage 抛 TypeError 把 run 判死(2026-09-05 茅台 run 事故)。
+    // loadCalcs 已在源头按 calculation_id 过滤参数文件,这里是第二道防线。
+    if (!c.record.output) continue;
     if (c.record.output.status === "ok" && (c.record.inputs_refs ?? []).length === 0)
       errors.push(`${path.basename(c.file)} 没有 inputs_refs:每个计算必须引用其输入 evidence / calculation id`);
   }


### PR DESCRIPTION
## 问题

agent 为绕过 shell 长参数限制，会往 `calcs/` 里写临时参数文件（`args_*`/`sq_*` 等，只含实参、没有 `calculation_id`/`output`）。`loadCalcs` 收 `calcs/` 下**所有** json，`validator.ts` 遍历 `run.calcs` 时直接读 `c.record.output.status` → 撞上参数文件抛 `TypeError`，**把整个 run 判死**。

## 复现（2026-09-05 茅台 run `20260905-000937-600519`）

时间线：
- `16:16:20` 财务阶段 `stages/financials.json` 写出（status=complete，62 条证据）
- `16:16:38` Stop 钩子复检 → `validateStage` 扫 `calcs/` 撞上 **12 个** `args_*`/`sq_*` 参数文件
  → `TypeError: Cannot read properties of undefined (reading 'status')`
  → 编排层把整个 run 判死（EXIT=3），尽管财务阶段实际已完成

`calcs/` 共 22 个 json，其中 12 个是参数文件（无 `calculation_id`）。

## 修复（两道防线）

1. **`loadCalcs` 源头过滤**：只收带 `calculation_id` 字符串的记录，参数文件不进入 `run.calcs`
2. **`validator.ts` 防御**：遍历前 `if (!c.record.output) continue`——output 缺失的异常记录不再让整个 `validateStage` 抛 TypeError

## 验证

- 用崩溃的 `20260905-000937-600519` run 重放 `loadRun` + `validateStage`：
  **修前 TypeError → 修后 `validateStage(financials) ok=true errors=0`**
- `loadCalcs` 收 10 个（过滤掉 12 个参数文件）
- `tsc --noEmit` 干净
- 2 个既有失败是 `local-vllm.json` base_url=http 不符合 provider schema 的环境问题，与本改动无关

## 影响面

仅 `orchestrator/src/merge.ts`（`loadCalcs` 加过滤）+ `orchestrator/src/validator.ts`（加 1 行防御）。不改变任何标准计算记录的校验行为。